### PR TITLE
Feature/derive agent tools

### DIFF
--- a/claude/src/test/scala/sttp/ai/claude/agent/ClaudeAgentBackendSpec.scala
+++ b/claude/src/test/scala/sttp/ai/claude/agent/ClaudeAgentBackendSpec.scala
@@ -59,7 +59,7 @@ class ClaudeAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
 
     backend.convertedTools.head match {
       case raw: Tool.CustomRaw =>
-        raw.inputSchema shouldBe parse("""{"type":"object"}""").value
+        raw.inputSchema shouldBe parse("""{"type":"object","properties":{}}""").value
       case other => fail(s"expected Tool.CustomRaw, got $other")
     }
   }
@@ -101,7 +101,7 @@ class ClaudeAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
     val backend = new ClaudeAgentBackend[Identity](client, _ => ClaudeModel.ClaudeHaiku4_5, Seq(tool), None, None)(IdentityMonad)
 
     backend.convertedTools.head match {
-      case raw: Tool.CustomRaw => raw.inputSchema shouldBe parse("""{"type":"object"}""").value
+      case raw: Tool.CustomRaw => raw.inputSchema shouldBe parse("""{"type":"object","properties":{}}""").value
       case other               => fail(s"expected Tool.CustomRaw, got $other")
     }
   }

--- a/core/src/main/scala-3/sttp/ai/core/agent/AgentTools.scala
+++ b/core/src/main/scala-3/sttp/ai/core/agent/AgentTools.scala
@@ -45,12 +45,26 @@ object AgentTools {
 
     def fail(msg: String): Nothing = report.errorAndAbort(s"AgentTools.derive[${renderType(sTpe)}]: $msg")
 
-    def descriptionOf(sym: Symbol): Option[String] =
+    def annotationTextOf(sym: Symbol): Option[String] =
       sym.getAnnotation(descriptionSym).map {
         case Apply(_, List(Literal(StringConstant(text))))              => text
         case Apply(_, List(NamedArg(_, Literal(StringConstant(text))))) => text
         case _ => fail(s"the @description annotation on '${sym.name}' must be given a string literal")
       }
+
+    // Annotations are not inherited onto overriding symbols in Scala 3, so when `S` is inferred as an implementation
+    // class (e.g. `AgentTools.derive(new WeatherImpl)`), `m` is the impl's method and carries no annotations of its
+    // own even though the trait method it overrides does. Fall back through `allOverriddenSymbols`, first hit wins.
+    def descriptionOf(sym: Symbol): Option[String] =
+      (sym :: sym.allOverriddenSymbols.toList).view.flatMap(annotationTextOf).headOption
+
+    // Same fallback for parameter descriptions: if the method's own parameter symbol has no annotation, check the
+    // corresponding parameter (by position in the single term parameter list) of each overridden method.
+    def paramDescriptionOf(m: Symbol, paramIndex: Int, p: Symbol): Option[String] = {
+      def paramOfOverride(o: Symbol): Option[Symbol] =
+        o.paramSymss.filterNot(_.exists(_.isTypeParam)).flatten.lift(paramIndex)
+      (p :: m.allOverriddenSymbols.toList.flatMap(paramOfOverride)).view.flatMap(annotationTextOf).headOption
+    }
 
     val excludedOwners = Set(defn.AnyClass, defn.AnyRefClass, defn.ObjectClass)
     val methods = sTpe.typeSymbol.methodMembers
@@ -60,6 +74,7 @@ object AgentTools {
       .filterNot(m => excludedOwners.contains(m.owner))
       .filterNot(m => m.allOverriddenSymbols.exists(o => excludedOwners.contains(o.owner)))
       .filterNot(_.name.contains("$"))
+      .filterNot(m => m.flags.is(Flags.FieldAccessor)) // getters/setters are properties, not tools
       .filter(_.paramSymss.nonEmpty) // parameterless accessors are properties, not tools
       .sortBy(_.name)
 
@@ -89,7 +104,7 @@ object AgentTools {
             val decoder = Expr.summon[Decoder[ft]].getOrElse(missing(s"io.circe.Decoder[$tpeName]"))
             val encoder = Expr.summon[Encoder[ft]].getOrElse(missing(s"io.circe.Encoder[$tpeName]"))
             val described: Expr[TapirSchema[ft]] =
-              descriptionOf(p).fold(schema)(d => '{ $schema.description(${ Expr(d) }) })
+              paramDescriptionOf(m, i, p).fold(schema)(d => '{ $schema.description(${ Expr(d) }) })
             val idx = Expr(i)
             val field: Expr[SProductField[Tup]] = '{
               SProductField[Tup, ft](

--- a/core/src/main/scala-3/sttp/ai/core/agent/AgentTools.scala
+++ b/core/src/main/scala-3/sttp/ai/core/agent/AgentTools.scala
@@ -33,7 +33,11 @@ object AgentTools {
     val sTpe = TypeRepr.of[S]
     val descriptionSym = TypeRepr.of[TapirSchema.annotations.description].typeSymbol
 
-    def fail(msg: String): Nothing = report.errorAndAbort(s"AgentTools.derive[${sTpe.show}]: $msg")
+    // Note: uses the bare symbol name rather than `sTpe.show`. When this macro is exercised via
+    // scala.compiletime.testing.typeCheckErrors (see AgentToolsDeriveErrorsSpec), `S` is a type declared inside the
+    // typechecked snippet; `.show`ing such a type after other symbol lookups (methodMembers, getAnnotation, ...)
+    // have run triggers a dotty CyclicReference in that harness. The plain symbol name avoids forcing that printing.
+    def fail(msg: String): Nothing = report.errorAndAbort(s"AgentTools.derive[${sTpe.typeSymbol.name}]: $msg")
 
     def descriptionOf(sym: Symbol): Option[String] =
       sym.getAnnotation(descriptionSym).map {
@@ -73,9 +77,11 @@ object AgentTools {
           case '[ft] =>
             def missing(what: String): Nothing =
               fail(s"no given $what for parameter '${p.name}' of method '${m.name}'")
-            val schema = Expr.summon[TapirSchema[ft]].getOrElse(missing(s"sttp.tapir.Schema[${tpe.show}]"))
-            val decoder = Expr.summon[Decoder[ft]].getOrElse(missing(s"io.circe.Decoder[${tpe.show}]"))
-            val encoder = Expr.summon[Encoder[ft]].getOrElse(missing(s"io.circe.Encoder[${tpe.show}]"))
+            // `.typeSymbol.name` rather than `.show`, for the same CyclicReference reason as in `fail` above.
+            val tpeName = tpe.typeSymbol.name
+            val schema = Expr.summon[TapirSchema[ft]].getOrElse(missing(s"sttp.tapir.Schema[$tpeName]"))
+            val decoder = Expr.summon[Decoder[ft]].getOrElse(missing(s"io.circe.Decoder[$tpeName]"))
+            val encoder = Expr.summon[Encoder[ft]].getOrElse(missing(s"io.circe.Encoder[$tpeName]"))
             val described: Expr[TapirSchema[ft]] =
               descriptionOf(p).fold(schema)(d => '{ $schema.description(${ Expr(d) }) })
             val idx = Expr(i)

--- a/core/src/main/scala-3/sttp/ai/core/agent/AgentTools.scala
+++ b/core/src/main/scala-3/sttp/ai/core/agent/AgentTools.scala
@@ -33,11 +33,17 @@ object AgentTools {
     val sTpe = TypeRepr.of[S]
     val descriptionSym = TypeRepr.of[TapirSchema.annotations.description].typeSymbol
 
-    // Note: uses the bare symbol name rather than `sTpe.show`. When this macro is exercised via
-    // scala.compiletime.testing.typeCheckErrors (see AgentToolsDeriveErrorsSpec), `S` is a type declared inside the
-    // typechecked snippet; `.show`ing such a type after other symbol lookups (methodMembers, getAnnotation, ...)
-    // have run triggers a dotty CyclicReference in that harness. The plain symbol name avoids forcing that printing.
-    def fail(msg: String): Nothing = report.errorAndAbort(s"AgentTools.derive[${sTpe.typeSymbol.name}]: $msg")
+    // Renders a type from bare symbol names (recursing into type arguments) rather than via `tpe.show`. When this
+    // macro is exercised via scala.compiletime.testing.typeCheckErrors (see AgentToolsDeriveErrorsSpec), types can be
+    // declared inside the typechecked snippet; `.show`ing such a type after other symbol lookups (methodMembers,
+    // getAnnotation, ...) have run triggers a dotty CyclicReference in that harness. Recursing through symbol names
+    // avoids forcing that printing while still preserving type arguments (e.g. `List[Foo]`, not just `List`).
+    def renderType(t: TypeRepr): String = t.dealias match {
+      case AppliedType(base, args) => s"${base.typeSymbol.name}[${args.map(renderType).mkString(", ")}]"
+      case other                   => other.typeSymbol.name
+    }
+
+    def fail(msg: String): Nothing = report.errorAndAbort(s"AgentTools.derive[${renderType(sTpe)}]: $msg")
 
     def descriptionOf(sym: Symbol): Option[String] =
       sym.getAnnotation(descriptionSym).map {
@@ -77,8 +83,8 @@ object AgentTools {
           case '[ft] =>
             def missing(what: String): Nothing =
               fail(s"no given $what for parameter '${p.name}' of method '${m.name}'")
-            // `.typeSymbol.name` rather than `.show`, for the same CyclicReference reason as in `fail` above.
-            val tpeName = tpe.typeSymbol.name
+            // `renderType` rather than `.show`, for the same CyclicReference reason as in `fail` above.
+            val tpeName = renderType(tpe)
             val schema = Expr.summon[TapirSchema[ft]].getOrElse(missing(s"sttp.tapir.Schema[$tpeName]"))
             val decoder = Expr.summon[Decoder[ft]].getOrElse(missing(s"io.circe.Decoder[$tpeName]"))
             val encoder = Expr.summon[Encoder[ft]].getOrElse(missing(s"io.circe.Encoder[$tpeName]"))

--- a/core/src/main/scala-3/sttp/ai/core/agent/AgentTools.scala
+++ b/core/src/main/scala-3/sttp/ai/core/agent/AgentTools.scala
@@ -138,8 +138,13 @@ object AgentTools {
             val schema = Expr.summon[TapirSchema[ft]].getOrElse(missing(s"sttp.tapir.Schema[$tpeName]"))
             val decoder = Expr.summon[Decoder[ft]].getOrElse(missing(s"io.circe.Decoder[$tpeName]"))
             val encoder = Expr.summon[Encoder[ft]].getOrElse(missing(s"io.circe.Encoder[$tpeName]"))
+            // Only Option parameters are optional properties (as documented). Tapir marks iterable schemas
+            // isOptional=true, which would drop e.g. a List parameter from `required` even though the generated
+            // circe decoder fails on a missing key - pin optionality to the parameter's Option-ness instead.
+            val optionAligned: Expr[TapirSchema[ft]] =
+              if (optionalFlags(i)) schema else '{ $schema.copy(isOptional = false) }
             val described: Expr[TapirSchema[ft]] =
-              paramDescriptionOf(m, i, p).fold(schema)(d => '{ $schema.description(${ Expr(d) }) })
+              paramDescriptionOf(m, i, p).fold(optionAligned)(d => '{ $optionAligned.description(${ Expr(d) }) })
             val idx = Expr(i)
             val field: Expr[SProductField[Tup]] = '{
               SProductField[Tup, ft](
@@ -173,6 +178,16 @@ object AgentTools {
 
           override def apply(c: io.circe.HCursor): Decoder.Result[Tup] =
             if (!c.value.isObject) Left(DecodingFailure("Tool arguments must be a JSON object", c.history))
+            else if (c.value.asObject.exists(_.keys.exists(k => !names.contains(k))))
+              // Unknown keys are rejected rather than ignored: with all-Option tools a misspelled argument key would
+              // otherwise silently decode to None and execute, instead of producing an error the loop can feed back.
+              Left(
+                DecodingFailure(
+                  s"unknown tool argument(s): ${c.value.asObject.get.keys.filterNot(names.contains).mkString(", ")}; " +
+                    s"expected: ${names.mkString(", ")}",
+                  c.history
+                )
+              )
             else {
               val values = new Array[Any](${ Expr(arity) })
               var i = 0

--- a/core/src/main/scala-3/sttp/ai/core/agent/AgentTools.scala
+++ b/core/src/main/scala-3/sttp/ai/core/agent/AgentTools.scala
@@ -1,0 +1,179 @@
+package sttp.ai.core.agent
+
+import io.circe.{Codec, Decoder, DecodingFailure, Encoder, Json, JsonObject}
+import sttp.shared.Identity
+import sttp.tapir.SchemaType.{SProduct, SProductField}
+import sttp.tapir.{FieldName, Schema as TapirSchema}
+
+import scala.quoted.*
+
+/** Derives a set of [[AgentTool]]s from the public methods of a service trait (or class).
+  *
+  * A method becomes a tool iff it is public, has exactly one (possibly empty) parameter list, and is not declared on
+  * `Any`/`AnyRef`/`Object` (inherited trait methods are included). Parameterless accessors (`def foo: String`, `val`s) are skipped. The
+  * tool name is the method name, JSON property names are the parameter names, and each method must carry a
+  * [[sttp.tapir.Schema.annotations.description]] annotation (optionally also on parameters, for property descriptions). `Option` parameters
+  * become non-required properties. Each parameter type needs given tapir `Schema`, circe `Decoder` and `Encoder` instances.
+  *
+  * Scala 3 only: on Scala 2.13 define tools individually with [[AgentTool.fromFunction]].
+  */
+object AgentTools {
+
+  /** Derives tools from a synchronous service: every method must return `String`. */
+  inline def derive[S](service: S): Seq[AgentTool[Identity, ?]] =
+    deriveF[Identity, S](service)
+
+  /** Derives tools from an effectful service: every method must return `F[String]`. */
+  inline def deriveF[F[_], S](service: S): Seq[AgentTool[F, ?]] =
+    ${ deriveImpl[F, S]('service) }
+
+  private def deriveImpl[F[_]: Type, S: Type](service: Expr[S])(using Quotes): Expr[Seq[AgentTool[F, ?]]] = {
+    import quotes.reflect.*
+
+    val sTpe = TypeRepr.of[S]
+    val descriptionSym = TypeRepr.of[TapirSchema.annotations.description].typeSymbol
+
+    def fail(msg: String): Nothing = report.errorAndAbort(s"AgentTools.derive[${sTpe.show}]: $msg")
+
+    def descriptionOf(sym: Symbol): Option[String] =
+      sym.getAnnotation(descriptionSym).map {
+        case Apply(_, List(Literal(StringConstant(text))))              => text
+        case Apply(_, List(NamedArg(_, Literal(StringConstant(text))))) => text
+        case _ => fail(s"the @description annotation on '${sym.name}' must be given a string literal")
+      }
+
+    val excludedOwners = Set(defn.AnyClass, defn.AnyRefClass, defn.ObjectClass)
+    val methods = sTpe.typeSymbol.methodMembers
+      .filterNot(_.isClassConstructor)
+      .filterNot(m => m.flags.is(Flags.Synthetic) || m.flags.is(Flags.Artifact))
+      .filterNot(m => m.flags.is(Flags.Private) || m.flags.is(Flags.Protected) || m.privateWithin.isDefined)
+      .filterNot(m => excludedOwners.contains(m.owner))
+      .filterNot(m => m.allOverriddenSymbols.exists(o => excludedOwners.contains(o.owner)))
+      .filterNot(_.name.contains("$"))
+      .filter(_.paramSymss.nonEmpty) // parameterless accessors are properties, not tools
+      .sortBy(_.name)
+
+    methods.groupBy(_.name).collect { case (n, ms) if ms.sizeIs > 1 => n }.toList.sorted match {
+      case Nil        => ()
+      case overloaded => fail(s"overloaded methods are not supported (duplicate tool names): ${overloaded.mkString(", ")}")
+    }
+
+    // Builds one tool for a method whose input type is Tup, the tuple of its parameter types. Tuple elements are
+    // accessed positionally via Product, so no Tuple upper bound is needed on Tup.
+    def buildTool[Tup: Type](
+        m: Symbol,
+        toolDescription: String,
+        params: List[Symbol],
+        paramTypes: List[TypeRepr]
+    ): Expr[AgentTool[F, Tup]] = {
+      val arity = params.size
+
+      val fieldInstances = params.zip(paramTypes).zipWithIndex.map { case ((p, tpe), i) =>
+        tpe.asType match {
+          case '[ft] =>
+            def missing(what: String): Nothing =
+              fail(s"no given $what for parameter '${p.name}' of method '${m.name}'")
+            val schema = Expr.summon[TapirSchema[ft]].getOrElse(missing(s"sttp.tapir.Schema[${tpe.show}]"))
+            val decoder = Expr.summon[Decoder[ft]].getOrElse(missing(s"io.circe.Decoder[${tpe.show}]"))
+            val encoder = Expr.summon[Encoder[ft]].getOrElse(missing(s"io.circe.Encoder[${tpe.show}]"))
+            val described: Expr[TapirSchema[ft]] =
+              descriptionOf(p).fold(schema)(d => '{ $schema.description(${ Expr(d) }) })
+            val idx = Expr(i)
+            val field: Expr[SProductField[Tup]] = '{
+              SProductField[Tup, ft](
+                FieldName(${ Expr(p.name) }),
+                $described,
+                (t: Tup) => Some(t.asInstanceOf[Product].productElement($idx).asInstanceOf[ft])
+              )
+            }
+            (Expr(p.name), field, '{ $decoder: Decoder[?] }, '{ $encoder: Encoder[?] })
+        }
+      }
+
+      val namesExpr = Expr.ofList(fieldInstances.map(_._1))
+      val fieldsExpr = Expr.ofList(fieldInstances.map(_._2))
+      val decodersExpr = Expr.ofList(fieldInstances.map(_._3))
+      val encodersExpr = Expr.ofList(fieldInstances.map(_._4))
+
+      val schemaExpr: Expr[TapirSchema[Tup]] = '{ TapirSchema(SProduct[Tup]($fieldsExpr)) }
+
+      val codecExpr: Expr[Codec[Tup]] = '{
+        new Codec[Tup] {
+          private val names = $namesExpr
+          private val decoders = $decodersExpr
+          private val encoders = $encodersExpr
+
+          override def apply(c: io.circe.HCursor): Decoder.Result[Tup] = {
+            val values = new Array[Any](${ Expr(arity) })
+            var i = 0
+            var failure: DecodingFailure = null
+            while (i < values.length && (failure eq null)) {
+              decoders(i).tryDecode(c.downField(names(i))) match {
+                case Right(v) => values(i) = v
+                case Left(f)  => failure = f
+              }
+              i += 1
+            }
+            if (failure ne null) Left(failure) else Right(Tuple.fromArray(values).asInstanceOf[Tup])
+          }
+
+          override def apply(t: Tup): Json = {
+            val fields = names.iterator
+              .zip(t.asInstanceOf[Product].productIterator)
+              .zip(encoders.iterator)
+              .map { case ((name, value), enc) => name -> enc.asInstanceOf[Encoder[Any]](value) }
+              .filterNot(_._2.isNull)
+            Json.fromJsonObject(JsonObject.fromIterable(fields.toList))
+          }
+        }
+      }
+
+      val execExpr: Expr[Tup => F[String]] = '{ (input: Tup) =>
+        ${
+          val argTerms = paramTypes.zipWithIndex.map { case (tpe, i) =>
+            tpe.asType match {
+              case '[ft] => '{ input.asInstanceOf[Product].productElement(${ Expr(i) }).asInstanceOf[ft] }.asTerm
+            }
+          }
+          Apply(Select(service.asTerm, m), argTerms).asExprOf[F[String]]
+        }
+      }
+
+      '{ AgentTool.fromFunctionF[F, Tup](${ Expr(m.name) }, ${ Expr(toolDescription) })($execExpr)(using $schemaExpr, $codecExpr) }
+    }
+
+    val toolExprs: List[Expr[AgentTool[F, ?]]] = methods.map { m =>
+      if (m.paramSymss.exists(_.exists(_.isTypeParam)))
+        fail(s"method '${m.name}' has type parameters, which are not supported")
+
+      val termParamLists = m.paramSymss.filterNot(_.exists(_.isTypeParam))
+      if (termParamLists.sizeIs > 1)
+        fail(s"method '${m.name}' has multiple parameter lists, which are not supported")
+
+      val params = termParamLists.headOption.getOrElse(Nil)
+      if (params.exists(p => p.flags.is(Flags.Given) || p.flags.is(Flags.Implicit)))
+        fail(s"method '${m.name}' has implicit/using parameters, which are not supported")
+      if (params.exists(_.flags.is(Flags.HasDefault)))
+        fail(s"method '${m.name}' has default parameter values, which are not supported")
+
+      val toolDescription = descriptionOf(m).getOrElse(
+        fail(s"method '${m.name}' is missing a @description annotation (sttp.tapir.Schema.annotations.description)")
+      )
+
+      val (paramTypes, resultType) = sTpe.memberType(m) match {
+        case MethodType(_, tps, res) => (tps, res)
+        case other                   => fail(s"method '${m.name}' has an unsupported shape: ${other.show}")
+      }
+
+      if (!(resultType =:= TypeRepr.of[F[String]]))
+        fail(s"method '${m.name}' must return ${TypeRepr.of[F[String]].show}, but returns ${resultType.show}")
+
+      val tupleTpe = paramTypes.foldRight(TypeRepr.of[EmptyTuple])((t, acc) => TypeRepr.of[*:].appliedTo(List(t, acc)))
+      tupleTpe.asType match {
+        case '[tup] => buildTool[tup](m, toolDescription, params, paramTypes)
+      }
+    }
+
+    Expr.ofList(toolExprs)
+  }
+}

--- a/core/src/main/scala-3/sttp/ai/core/agent/AgentTools.scala
+++ b/core/src/main/scala-3/sttp/ai/core/agent/AgentTools.scala
@@ -45,11 +45,23 @@ object AgentTools {
 
     def fail(msg: String): Nothing = report.errorAndAbort(s"AgentTools.derive[${renderType(sTpe)}]: $msg")
 
+    // Accepts a string literal or any compile-time constant string (e.g. a `final val`), whose value lives in the
+    // argument's ConstantType rather than in a Literal tree.
+    def constText(t: Term): Option[String] = t match {
+      case Literal(StringConstant(text)) => Some(text)
+      case NamedArg(_, inner)            => constText(inner)
+      case _                             =>
+        t.tpe.widenTermRefByName.dealias match {
+          case ConstantType(StringConstant(text)) => Some(text)
+          case _                                  => None
+        }
+    }
+
     def annotationTextOf(sym: Symbol): Option[String] =
       sym.getAnnotation(descriptionSym).map {
-        case Apply(_, List(Literal(StringConstant(text))))              => text
-        case Apply(_, List(NamedArg(_, Literal(StringConstant(text))))) => text
-        case _ => fail(s"the @description annotation on '${sym.name}' must be given a string literal")
+        case Apply(_, List(arg)) =>
+          constText(arg).getOrElse(fail(s"the @description annotation on '${sym.name}' must be given a constant string"))
+        case _ => fail(s"the @description annotation on '${sym.name}' must be given a constant string")
       }
 
     // Annotations are not inherited onto overriding symbols in Scala 3, so when `S` is inferred as an implementation
@@ -67,16 +79,31 @@ object AgentTools {
     }
 
     val excludedOwners = Set(defn.AnyClass, defn.AnyRefClass, defn.ObjectClass)
-    val methods = sTpe.typeSymbol.methodMembers
+    val visibleMembers = sTpe.typeSymbol.methodMembers
       .filterNot(_.isClassConstructor)
       .filterNot(m => m.flags.is(Flags.Synthetic) || m.flags.is(Flags.Artifact))
       .filterNot(m => m.flags.is(Flags.Private) || m.flags.is(Flags.Protected) || m.privateWithin.isDefined)
       .filterNot(m => excludedOwners.contains(m.owner))
       .filterNot(m => m.allOverriddenSymbols.exists(o => excludedOwners.contains(o.owner)))
       .filterNot(_.name.contains("$"))
+
+    val methods = visibleMembers
       .filterNot(m => m.flags.is(Flags.FieldAccessor)) // getters/setters are properties, not tools
       .filter(_.paramSymss.nonEmpty) // parameterless accessors are properties, not tools
       .sortBy(_.name)
+
+    // A parameterless def is skipped as a property, but one that carries @description signals clear intent to expose
+    // a tool — fail loudly instead of silently dropping it.
+    visibleMembers
+      .filterNot(m => m.flags.is(Flags.FieldAccessor))
+      .filter(_.paramSymss.isEmpty)
+      .find(m => descriptionOf(m).isDefined)
+      .foreach { m =>
+        fail(
+          s"method '${m.name}' has a @description annotation but no parameter list; parameterless members are treated as " +
+            "properties, not tools - add an empty parameter list () to expose it as a tool"
+        )
+      }
 
     methods.groupBy(_.name).collect { case (n, ms) if ms.sizeIs > 1 => n }.toList.sorted match {
       case Nil        => ()
@@ -92,6 +119,14 @@ object AgentTools {
         paramTypes: List[TypeRepr]
     ): Expr[AgentTool[F, Tup]] = {
       val arity = params.size
+
+      val optionClass = Symbol.requiredClass("scala.Option")
+      val optionalFlags: List[Boolean] = paramTypes.map { tpe =>
+        tpe.dealias match {
+          case AppliedType(base, _) => base.typeSymbol == optionClass
+          case _                    => false
+        }
+      }
 
       val fieldInstances = params.zip(paramTypes).zipWithIndex.map { case ((p, tpe), i) =>
         tpe.asType match {
@@ -121,35 +156,48 @@ object AgentTools {
       val fieldsExpr = Expr.ofList(fieldInstances.map(_._2))
       val decodersExpr = Expr.ofList(fieldInstances.map(_._3))
       val encodersExpr = Expr.ofList(fieldInstances.map(_._4))
+      val optionalsExpr = Expr(optionalFlags)
 
-      val schemaExpr: Expr[TapirSchema[Tup]] = '{ TapirSchema(SProduct[Tup]($fieldsExpr)) }
+      // The root schema must be named: TapirSchemaToJsonSchema only collects nested named schemas (e.g. case-class
+      // parameters) into $defs when the root itself has a name - an unnamed root leaves dangling $refs that providers
+      // reject.
+      val schemaExpr: Expr[TapirSchema[Tup]] =
+        '{ TapirSchema(SProduct[Tup]($fieldsExpr), name = Some(TapirSchema.SName(${ Expr(m.name) } + "Input"))) }
 
       val codecExpr: Expr[Codec[Tup]] = '{
         new Codec[Tup] {
-          private val names = $namesExpr
-          private val decoders = $decodersExpr
-          private val encoders = $encodersExpr
+          private val names = $namesExpr.toIndexedSeq
+          private val decoders = $decodersExpr.toIndexedSeq
+          private val encoders = $encodersExpr.toIndexedSeq
+          private val optionals = $optionalsExpr.toIndexedSeq
 
-          override def apply(c: io.circe.HCursor): Decoder.Result[Tup] = {
-            val values = new Array[Any](${ Expr(arity) })
-            var i = 0
-            var failure: DecodingFailure = null
-            while (i < values.length && (failure eq null)) {
-              decoders(i).tryDecode(c.downField(names(i))) match {
-                case Right(v) => values(i) = v
-                case Left(f)  => failure = f
+          override def apply(c: io.circe.HCursor): Decoder.Result[Tup] =
+            if (!c.value.isObject) Left(DecodingFailure("Tool arguments must be a JSON object", c.history))
+            else {
+              val values = new Array[Any](${ Expr(arity) })
+              var i = 0
+              var failure: DecodingFailure = null
+              while (i < values.length && (failure eq null)) {
+                decoders(i).tryDecode(c.downField(names(i))) match {
+                  case Right(v) => values(i) = v
+                  case Left(f)  => failure = f
+                }
+                i += 1
               }
-              i += 1
+              if (failure ne null) Left(failure) else Right(Tuple.fromArray(values).asInstanceOf[Tup])
             }
-            if (failure ne null) Left(failure) else Right(Tuple.fromArray(values).asInstanceOf[Tup])
-          }
 
           override def apply(t: Tup): Json = {
+            // Only Option-typed fields drop an encoded Json.Null (absent = None); a null produced by any other
+            // field's encoder is real data and must survive the round-trip.
             val fields = names.iterator
               .zip(t.asInstanceOf[Product].productIterator)
               .zip(encoders.iterator)
-              .map { case ((name, value), enc) => name -> enc.asInstanceOf[Encoder[Any]](value) }
-              .filterNot(_._2.isNull)
+              .zipWithIndex
+              .flatMap { case (((name, value), enc), i) =>
+                val encoded = enc.asInstanceOf[Encoder[Any]](value)
+                if (encoded.isNull && optionals(i)) None else Some(name -> encoded)
+              }
             Json.fromJsonObject(JsonObject.fromIterable(fields.toList))
           }
         }
@@ -189,11 +237,21 @@ object AgentTools {
 
       val (paramTypes, resultType) = sTpe.memberType(m) match {
         case MethodType(_, tps, res) => (tps, res)
-        case other                   => fail(s"method '${m.name}' has an unsupported shape: ${other.show}")
+        case other                   => fail(s"method '${m.name}' has an unsupported shape: ${renderType(other)}")
       }
 
-      if (!(resultType =:= TypeRepr.of[F[String]]))
-        fail(s"method '${m.name}' must return ${TypeRepr.of[F[String]].show}, but returns ${resultType.show}")
+      params.zip(paramTypes).foreach { case (p, tpe) =>
+        tpe match {
+          case ByNameType(_) => fail(s"parameter '${p.name}' of method '${m.name}' is by-name, which is not supported")
+          case _ if tpe.typeSymbol == defn.RepeatedParamClass =>
+            fail(s"parameter '${p.name}' of method '${m.name}' is a vararg, which is not supported")
+          case _ => ()
+        }
+      }
+
+      // <:< (not =:=) so covariant overrides conform, e.g. an impl narrowing Option[String] to Some[String].
+      if (!(resultType <:< TypeRepr.of[F[String]]))
+        fail(s"method '${m.name}' must return ${renderType(TypeRepr.of[F[String]])}, but returns ${renderType(resultType)}")
 
       val tupleTpe = paramTypes.foldRight(TypeRepr.of[EmptyTuple])((t, acc) => TypeRepr.of[*:].appliedTo(List(t, acc)))
       tupleTpe.asType match {

--- a/core/src/main/scala/sttp/ai/core/agent/AgentTool.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentTool.scala
@@ -61,15 +61,26 @@ object AgentTool {
       override def execute(input: Map[String, Json]): F[String] = f(input)
     }
 
-  /** Providers require a tool's input/parameters schema to be a JSON-Schema *object*; MCP allows schemas that omit `type` (e.g. `{}` for
-    * no-argument tools) and the boolean form `true` ("any input is valid"). Both are normalized to a minimal object schema; anything else
-    * passes through unchanged.
+  /** Providers require a tool's input/parameters schema to be a JSON-Schema *object*, and some also require the `properties` key to be
+    * present on it; MCP allows schemas that omit `type` (e.g. `{}` for no-argument tools) and the boolean form `true` ("any input is
+    * valid"). All are normalized to a minimal object schema. The `properties` repair is skipped for schemas that define their shape another
+    * way (`$ref`, combinators, a discriminator, or an explicit non-false `additionalProperties` for map-like objects) — injecting an empty
+    * `properties` there would misrepresent the schema.
     */
   private[ai] def ensureObjectType(schema: Json): Json =
-    if (schema.isBoolean) Json.obj("type" -> Json.fromString("object"))
+    if (schema.isBoolean) ensureObjectType(Json.obj("type" -> Json.fromString("object")))
     else
       schema.asObject match {
-        case Some(obj) if !obj.contains("type") => Json.fromJsonObject(obj.add("type", Json.fromString("object")))
-        case _                                  => schema
+        case Some(obj) =>
+          val typed = if (obj.contains("type")) obj else obj.add("type", Json.fromString("object"))
+          val shapeDefinedElsewhere =
+            Seq("$ref", "oneOf", "anyOf", "allOf", "discriminator").exists(typed.contains) ||
+              typed("additionalProperties").exists(ap => !ap.isBoolean || ap.asBoolean.contains(true))
+          val repaired =
+            if (typed("type").contains(Json.fromString("object")) && !typed.contains("properties") && !shapeDefinedElsewhere)
+              typed.add("properties", Json.obj())
+            else typed
+          Json.fromJsonObject(repaired)
+        case None => schema
       }
 }

--- a/core/src/test/scala-3/sttp/ai/core/agent/AgentToolsDeriveErrorsSpec.scala
+++ b/core/src/test/scala-3/sttp/ai/core/agent/AgentToolsDeriveErrorsSpec.scala
@@ -103,4 +103,35 @@ class AgentToolsDeriveErrorsSpec extends AnyFlatSpec with Matchers {
     """)
     messagesOf(errors) should include("List[")
   }
+
+  it should "reject by-name parameters with a targeted error" in {
+    val errors = typeCheckErrors("""
+      trait ByName {
+        @sttp.tapir.Schema.annotations.description("d") def a(x: => Int): String
+      }
+      sttp.ai.core.agent.AgentTools.derive[ByName](null.asInstanceOf[ByName])
+    """)
+    messagesOf(errors) should include("is by-name")
+  }
+
+  it should "reject vararg parameters with a targeted error" in {
+    val errors = typeCheckErrors("""
+      trait Vararg {
+        @sttp.tapir.Schema.annotations.description("d") def a(xs: Int*): String
+      }
+      sttp.ai.core.agent.AgentTools.derive[Vararg](null.asInstanceOf[Vararg])
+    """)
+    messagesOf(errors) should include("is a vararg")
+  }
+
+  it should "reject a parameterless method that carries @description instead of silently skipping it" in {
+    val errors = typeCheckErrors("""
+      trait Acc {
+        @sttp.tapir.Schema.annotations.description("annotated accessor") def status: String
+        @sttp.tapir.Schema.annotations.description("real tool") def go(x: Int): String
+      }
+      sttp.ai.core.agent.AgentTools.derive[Acc](null.asInstanceOf[Acc])
+    """)
+    messagesOf(errors) should include("no parameter list")
+  }
 }

--- a/core/src/test/scala-3/sttp/ai/core/agent/AgentToolsDeriveErrorsSpec.scala
+++ b/core/src/test/scala-3/sttp/ai/core/agent/AgentToolsDeriveErrorsSpec.scala
@@ -1,0 +1,95 @@
+package sttp.ai.core.agent
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.compiletime.testing.typeCheckErrors
+
+class AgentToolsDeriveErrorsSpec extends AnyFlatSpec with Matchers {
+
+  private def messagesOf(errors: List[scala.compiletime.testing.Error]): String =
+    errors.map(_.message).mkString("\n")
+
+  behavior of "AgentTools.derive compile-time validation"
+
+  it should "reject a method without @description" in {
+    val errors = typeCheckErrors("""
+      trait NoDesc { def a(x: Int): String }
+      sttp.ai.core.agent.AgentTools.derive[NoDesc](null.asInstanceOf[NoDesc])
+    """)
+    messagesOf(errors) should include("missing a @description")
+  }
+
+  it should "reject overloaded methods" in {
+    val errors = typeCheckErrors("""
+      trait Overloaded {
+        @sttp.tapir.Schema.annotations.description("one") def a(x: Int): String
+        @sttp.tapir.Schema.annotations.description("two") def a(x: String): String
+      }
+      sttp.ai.core.agent.AgentTools.derive[Overloaded](null.asInstanceOf[Overloaded])
+    """)
+    messagesOf(errors) should include("overloaded methods are not supported")
+  }
+
+  it should "reject a wrong return type" in {
+    val errors = typeCheckErrors("""
+      trait WrongReturn {
+        @sttp.tapir.Schema.annotations.description("d") def a(x: Int): Int
+      }
+      sttp.ai.core.agent.AgentTools.derive[WrongReturn](null.asInstanceOf[WrongReturn])
+    """)
+    messagesOf(errors) should include("must return")
+  }
+
+  it should "reject default parameter values" in {
+    val errors = typeCheckErrors("""
+      trait Defaults {
+        @sttp.tapir.Schema.annotations.description("d") def a(x: Int = 5): String
+      }
+      sttp.ai.core.agent.AgentTools.derive[Defaults](null.asInstanceOf[Defaults])
+    """)
+    messagesOf(errors) should include("default parameter values")
+  }
+
+  it should "reject multiple parameter lists" in {
+    val errors = typeCheckErrors("""
+      trait Curried {
+        @sttp.tapir.Schema.annotations.description("d") def a(x: Int)(y: Int): String
+      }
+      sttp.ai.core.agent.AgentTools.derive[Curried](null.asInstanceOf[Curried])
+    """)
+    messagesOf(errors) should include("multiple parameter lists")
+  }
+
+  it should "reject using parameters" in {
+    val errors = typeCheckErrors("""
+      trait Using {
+        @sttp.tapir.Schema.annotations.description("d") def a(x: Int)(using y: Ordering[Int]): String
+      }
+      sttp.ai.core.agent.AgentTools.derive[Using](null.asInstanceOf[Using])
+    """)
+    val messages = messagesOf(errors)
+    (messages.contains("implicit/using parameters") || messages.contains("multiple parameter lists")) shouldBe true
+  }
+
+  it should "reject method type parameters" in {
+    val errors = typeCheckErrors("""
+      trait Poly {
+        @sttp.tapir.Schema.annotations.description("d") def a[T](x: T): String
+      }
+      sttp.ai.core.agent.AgentTools.derive[Poly](null.asInstanceOf[Poly])
+    """)
+    messagesOf(errors) should include("type parameters")
+  }
+
+  it should "reject a parameter type without a given Schema" in {
+    val errors = typeCheckErrors("""
+      class Opaque(val x: Int)
+      trait NoSchema {
+        @sttp.tapir.Schema.annotations.description("d") def a(o: Opaque): String
+      }
+      sttp.ai.core.agent.AgentTools.derive[NoSchema](null.asInstanceOf[NoSchema])
+    """)
+    messagesOf(errors) should include("no given sttp.tapir.Schema")
+  }
+}

--- a/core/src/test/scala-3/sttp/ai/core/agent/AgentToolsDeriveErrorsSpec.scala
+++ b/core/src/test/scala-3/sttp/ai/core/agent/AgentToolsDeriveErrorsSpec.scala
@@ -92,4 +92,15 @@ class AgentToolsDeriveErrorsSpec extends AnyFlatSpec with Matchers {
     """)
     messagesOf(errors) should include("no given sttp.tapir.Schema")
   }
+
+  it should "preserve type arguments in the error message for a generic parameter type without a given Schema" in {
+    val errors = typeCheckErrors("""
+      class Opaque(val x: Int)
+      trait NoSchema {
+        @sttp.tapir.Schema.annotations.description("d") def a(o: List[Opaque]): String
+      }
+      sttp.ai.core.agent.AgentTools.derive[NoSchema](null.asInstanceOf[NoSchema])
+    """)
+    messagesOf(errors) should include("List[")
+  }
 }

--- a/core/src/test/scala-3/sttp/ai/core/agent/AgentToolsDeriveSpec.scala
+++ b/core/src/test/scala-3/sttp/ai/core/agent/AgentToolsDeriveSpec.scala
@@ -1,0 +1,72 @@
+package sttp.ai.core.agent
+
+import io.circe.Json
+import io.circe.syntax.*
+import org.scalatest.OptionValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.shared.Identity
+import sttp.tapir.Schema.annotations.description
+
+class AgentToolsDeriveSpec extends AnyFlatSpec with Matchers with OptionValues {
+
+  trait WeatherService {
+    @description("Get current weather")
+    def currentWeather(@description("IATA city code") city: String, unit: String): String
+
+    @description("Get a forecast")
+    def forecast(city: String, days: Int): String
+
+    private def helper(x: String): String = x
+  }
+
+  class WeatherImpl extends WeatherService {
+    override def currentWeather(city: String, unit: String): String = s"weather:$city:$unit"
+    override def forecast(city: String, days: Int): String = s"forecast:$city:$days"
+  }
+
+  // Decodes args with the tool's own codec, then executes — the same path the agent loop uses (cf. LoopAgent.executeTool).
+  // The polymorphic T is bound from the tool's wildcard type via capture conversion, so codec and execute provably agree on T.
+  private def run[T](tool: AgentTool[Identity, T], args: Json): String =
+    tool.execute(tool.codec.decodeJson(args).fold(e => fail(s"decode failed: $e"), identity))
+
+  behavior of "AgentTools.derive"
+
+  it should "produce one tool per public method, sorted by name, with descriptions" in {
+    val tools = AgentTools.derive[WeatherService](new WeatherImpl)
+    tools.map(_.name) shouldBe Seq("currentWeather", "forecast")
+    tools.map(_.description) shouldBe Seq("Get current weather", "Get a forecast")
+  }
+
+  it should "produce object schemas with one property per parameter, all required" in {
+    val tools = AgentTools.derive[WeatherService](new WeatherImpl)
+    val raw = tools.find(_.name == "forecast").value.rawJsonSchema
+    raw.hcursor.downField("properties").keys.value.toSet shouldBe Set("city", "days")
+    raw.hcursor.downField("properties").downField("city").get[String]("type") shouldBe Right("string")
+    raw.hcursor.downField("properties").downField("days").get[String]("type") shouldBe Right("integer")
+    raw.hcursor.downField("required").as[Set[String]] shouldBe Right(Set("city", "days"))
+  }
+
+  it should "decode JSON arguments and invoke the implementation" in {
+    val tools = AgentTools.derive[WeatherService](new WeatherImpl)
+    val forecast = tools.find(_.name == "forecast").value
+    run(forecast, Json.obj("city" -> "KRK".asJson, "days" -> 3.asJson)) shouldBe "forecast:KRK:3"
+    val current = tools.find(_.name == "currentWeather").value
+    run(current, Json.obj("city" -> "KRK".asJson, "unit" -> "C".asJson)) shouldBe "weather:KRK:C"
+  }
+
+  it should "report a decode failure for malformed arguments instead of executing" in {
+    val tools = AgentTools.derive[WeatherService](new WeatherImpl)
+    val forecast = tools.find(_.name == "forecast").value
+    forecast.codec.decodeJson(Json.obj("city" -> "KRK".asJson, "days" -> "three".asJson)).isLeft shouldBe true
+  }
+
+  private def codecRoundTrip[T](tool: AgentTool[Identity, T], args: Json): Json =
+    tool.codec(tool.codec.decodeJson(args).toOption.value)
+
+  it should "encode a decoded value back to an equivalent JSON object" in {
+    val tools = AgentTools.derive[WeatherService](new WeatherImpl)
+    val args = Json.obj("city" -> "KRK".asJson, "days" -> 3.asJson)
+    codecRoundTrip(tools.find(_.name == "forecast").value, args) shouldBe args
+  }
+}

--- a/core/src/test/scala-3/sttp/ai/core/agent/AgentToolsDeriveSpec.scala
+++ b/core/src/test/scala-3/sttp/ai/core/agent/AgentToolsDeriveSpec.scala
@@ -127,4 +127,29 @@ class AgentToolsDeriveSpec extends AnyFlatSpec with Matchers with OptionValues {
     tools.map(_.name) shouldBe Seq("baseOp", "extendedOp")
     run(tools.head, Json.obj("x" -> 42.asJson)) shouldBe "base:42"
   }
+
+  trait EffectfulService {
+    @description("Fetch by id")
+    def fetch(id: Int): Option[String]
+
+    @description("List all")
+    def listAll(): Option[String]
+  }
+
+  class EffectfulImpl extends EffectfulService {
+    override def fetch(id: Int): Option[String] = Some(s"fetched:$id")
+    override def listAll(): Option[String] = None
+  }
+
+  private def runF[F[_], T](tool: AgentTool[F, T], args: Json): F[String] =
+    tool.execute(tool.codec.decodeJson(args).fold(e => fail(s"decode failed: $e"), identity))
+
+  behavior of "AgentTools.deriveF"
+
+  it should "derive tools whose execute returns F[String]" in {
+    val tools: Seq[AgentTool[Option, ?]] = AgentTools.deriveF[Option, EffectfulService](new EffectfulImpl)
+    tools.map(_.name) shouldBe Seq("fetch", "listAll")
+    runF(tools.find(_.name == "fetch").value, Json.obj("id" -> 7.asJson)) shouldBe Some("fetched:7")
+    runF(tools.find(_.name == "listAll").value, Json.obj()) shouldBe None
+  }
 }

--- a/core/src/test/scala-3/sttp/ai/core/agent/AgentToolsDeriveSpec.scala
+++ b/core/src/test/scala-3/sttp/ai/core/agent/AgentToolsDeriveSpec.scala
@@ -69,4 +69,62 @@ class AgentToolsDeriveSpec extends AnyFlatSpec with Matchers with OptionValues {
     val args = Json.obj("city" -> "KRK".asJson, "days" -> 3.asJson)
     codecRoundTrip(tools.find(_.name == "forecast").value, args) shouldBe args
   }
+
+  trait RichService {
+    @description("Search entries")
+    def search(query: String, limit: Option[Int]): String
+
+    @description("Current time")
+    def now(): String
+  }
+
+  class RichImpl extends RichService {
+    override def search(query: String, limit: Option[Int]): String = s"search:$query:${limit.getOrElse(-1)}"
+    override def now(): String = "now"
+  }
+
+  it should "make Option parameters non-required and decode a missing key as None" in {
+    val tools = AgentTools.derive[RichService](new RichImpl)
+    val search = tools.find(_.name == "search").value
+    val raw = search.rawJsonSchema
+    raw.hcursor.downField("properties").keys.value.toSet shouldBe Set("query", "limit")
+    raw.hcursor.downField("required").as[Set[String]] shouldBe Right(Set("query"))
+    run(search, Json.obj("query" -> "cats".asJson)) shouldBe "search:cats:-1"
+    run(search, Json.obj("query" -> "cats".asJson, "limit" -> 5.asJson)) shouldBe "search:cats:5"
+  }
+
+  it should "attach parameter @description annotations as property descriptions" in {
+    val tools = AgentTools.derive[WeatherService](new WeatherImpl)
+    val raw = tools.find(_.name == "currentWeather").value.rawJsonSchema
+    raw.hcursor.downField("properties").downField("city").get[String]("description") shouldBe Right("IATA city code")
+    raw.hcursor.downField("properties").downField("unit").downField("description").succeeded shouldBe false
+  }
+
+  it should "support no-arg methods with an empty object schema" in {
+    val tools = AgentTools.derive[RichService](new RichImpl)
+    val now = tools.find(_.name == "now").value
+    AgentTool.ensureObjectType(now.rawJsonSchema).hcursor.get[String]("type") shouldBe Right("object")
+    run(now, Json.obj()) shouldBe "now"
+  }
+
+  trait BaseTools {
+    @description("Base op")
+    def baseOp(x: Int): String
+  }
+
+  trait ExtendedTools extends BaseTools {
+    @description("Extended op")
+    def extendedOp(y: String): String
+  }
+
+  class ExtendedImpl extends ExtendedTools {
+    override def baseOp(x: Int): String = s"base:$x"
+    override def extendedOp(y: String): String = s"ext:$y"
+  }
+
+  it should "include public methods inherited from parent traits" in {
+    val tools = AgentTools.derive[ExtendedTools](new ExtendedImpl)
+    tools.map(_.name) shouldBe Seq("baseOp", "extendedOp")
+    run(tools.head, Json.obj("x" -> 42.asJson)) shouldBe "base:42"
+  }
 }

--- a/core/src/test/scala-3/sttp/ai/core/agent/AgentToolsDeriveSpec.scala
+++ b/core/src/test/scala-3/sttp/ai/core/agent/AgentToolsDeriveSpec.scala
@@ -6,6 +6,7 @@ import org.scalatest.OptionValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.shared.Identity
+import sttp.tapir.Schema
 import sttp.tapir.Schema.annotations.description
 
 class AgentToolsDeriveSpec extends AnyFlatSpec with Matchers with OptionValues {
@@ -168,6 +169,71 @@ class AgentToolsDeriveSpec extends AnyFlatSpec with Matchers with OptionValues {
     tools.map(_.name) shouldBe Seq("doThing")
   }
 
+  case class Address(street: String, zip: String) derives io.circe.Codec.AsObject, Schema
+
+  trait AddressService {
+    @description("Locate an address")
+    def locate(addr: Address): String
+  }
+
+  class AddressImpl extends AddressService {
+    override def locate(addr: Address): String = s"${addr.street}/${addr.zip}"
+  }
+
+  it should "reference case-class parameter schemas through $defs with no dangling refs" in {
+    val tools = AgentTools.derive[AddressService](new AddressImpl)
+    val raw = tools.find(_.name == "locate").value.rawJsonSchema
+    val ref = raw.hcursor.downField("properties").downField("addr").get[String]("$ref").toOption.value
+    ref should startWith("#/$defs/")
+    val defName = ref.stripPrefix("#/$defs/")
+    raw.hcursor.downField("$defs").downField(defName).downField("properties").keys.value.toSet shouldBe Set("street", "zip")
+  }
+
+  it should "decode case-class arguments and invoke the implementation" in {
+    val tools = AgentTools.derive[AddressService](new AddressImpl)
+    val args = Json.obj("addr" -> Json.obj("street" -> "Main".asJson, "zip" -> "30-001".asJson))
+    run(tools.find(_.name == "locate").value, args) shouldBe "Main/30-001"
+  }
+
+  it should "reject non-object arguments, including for no-arg tools" in {
+    val tools = AgentTools.derive[RichService](new RichImpl)
+    tools.find(_.name == "now").value.codec.decodeJson(Json.fromString("junk")).isLeft shouldBe true
+    tools.find(_.name == "search").value.codec.decodeJson(Json.fromInt(3)).isLeft shouldBe true
+  }
+
+  object DescriptionConstants {
+    final val AddDescription = "Add via constant"
+  }
+
+  trait ConstDescService {
+    @description(DescriptionConstants.AddDescription)
+    def add(a: Int, b: Int): String
+  }
+
+  it should "accept compile-time constant strings as @description arguments" in {
+    val tools = AgentTools.derive[ConstDescService](new ConstDescService {
+      override def add(a: Int, b: Int): String = s"${a + b}"
+    })
+    tools.head.description shouldBe "Add via constant"
+  }
+
+  class Nully
+  given io.circe.Encoder[Nully] = _ => Json.Null
+  given io.circe.Decoder[Nully] = _ => Right(new Nully)
+  given Schema[Nully] = Schema.string.as[Nully]
+
+  trait NullService {
+    @description("Null probe")
+    def probe(marker: Nully, note: Option[String]): String
+  }
+
+  it should "keep a legitimately null-encoded non-Option field while dropping absent Options" in {
+    val tools = AgentTools.derive[NullService](new NullService {
+      override def probe(marker: Nully, note: Option[String]): String = "ok"
+    })
+    codecRoundTrip(tools.head, Json.obj("marker" -> Json.Null)) shouldBe Json.obj("marker" -> Json.Null)
+  }
+
   behavior of "AgentTools.deriveF"
 
   it should "derive tools whose execute returns F[String]" in {
@@ -175,5 +241,19 @@ class AgentToolsDeriveSpec extends AnyFlatSpec with Matchers with OptionValues {
     tools.map(_.name) shouldBe Seq("fetch", "listAll")
     runF(tools.find(_.name == "fetch").value, Json.obj("id" -> 7.asJson)) shouldBe Some("fetched:7")
     runF(tools.find(_.name == "listAll").value, Json.obj()) shouldBe None
+  }
+
+  trait CovariantService {
+    @description("Fetch by id")
+    def fetch(id: Int): Option[String]
+  }
+
+  class CovariantImpl extends CovariantService {
+    override def fetch(id: Int): Some[String] = Some(s"got:$id")
+  }
+
+  it should "accept covariantly narrowed return types when deriving from an implementation class" in {
+    val tools = AgentTools.deriveF[Option, CovariantImpl](new CovariantImpl)
+    runF(tools.head, Json.obj("id" -> 5.asJson)) shouldBe Some("got:5")
   }
 }

--- a/core/src/test/scala-3/sttp/ai/core/agent/AgentToolsDeriveSpec.scala
+++ b/core/src/test/scala-3/sttp/ai/core/agent/AgentToolsDeriveSpec.scala
@@ -104,8 +104,33 @@ class AgentToolsDeriveSpec extends AnyFlatSpec with Matchers with OptionValues {
   it should "support no-arg methods with an empty object schema" in {
     val tools = AgentTools.derive[RichService](new RichImpl)
     val now = tools.find(_.name == "now").value
-    AgentTool.ensureObjectType(now.rawJsonSchema).hcursor.get[String]("type") shouldBe Right("object")
+    // assert on the raw schema directly - going through ensureObjectType here would make the assertion vacuous,
+    // since that helper inserts the type key itself
+    now.rawJsonSchema.hcursor.get[String]("type") shouldBe Right("object")
+    AgentTool.ensureObjectType(now.rawJsonSchema).hcursor.downField("properties").succeeded shouldBe true
     run(now, Json.obj()) shouldBe "now"
+  }
+
+  it should "keep collection parameters required even though tapir marks iterable schemas optional" in {
+    trait ListService {
+      @description("Sum some numbers")
+      def sum(numbers: List[Int], label: Option[String]): String
+    }
+    val tools = AgentTools.derive[ListService](new ListService {
+      override def sum(numbers: List[Int], label: Option[String]): String = s"${label.getOrElse("sum")}:${numbers.sum}"
+    })
+    val raw = tools.head.rawJsonSchema
+    raw.hcursor.downField("required").as[Set[String]] shouldBe Right(Set("numbers"))
+    run(tools.head, Json.obj("numbers" -> Json.arr(1.asJson, 2.asJson))) shouldBe "sum:3"
+    tools.head.codec.decodeJson(Json.obj()).isLeft shouldBe true
+  }
+
+  it should "reject unknown argument keys instead of silently ignoring them" in {
+    val tools = AgentTools.derive[RichService](new RichImpl)
+    val search = tools.find(_.name == "search").value
+    val res = search.codec.decodeJson(Json.obj("query" -> "cats".asJson, "limt" -> 5.asJson))
+    res.isLeft shouldBe true
+    res.left.toOption.value.getMessage should include("limt")
   }
 
   trait BaseTools {

--- a/core/src/test/scala-3/sttp/ai/core/agent/AgentToolsDeriveSpec.scala
+++ b/core/src/test/scala-3/sttp/ai/core/agent/AgentToolsDeriveSpec.scala
@@ -144,6 +144,30 @@ class AgentToolsDeriveSpec extends AnyFlatSpec with Matchers with OptionValues {
   private def runF[F[_], T](tool: AgentTool[F, T], args: Json): F[String] =
     tool.execute(tool.codec.decodeJson(args).fold(e => fail(s"decode failed: $e"), identity))
 
+  it should "read @description annotations from the trait when S is inferred from an implementation class" in {
+    val tools = AgentTools.derive(new WeatherImpl)
+    tools.map(_.name) shouldBe Seq("currentWeather", "forecast")
+    tools.map(_.description) shouldBe Seq("Get current weather", "Get a forecast")
+    val raw = tools.find(_.name == "currentWeather").value.rawJsonSchema
+    raw.hcursor.downField("properties").downField("city").get[String]("description") shouldBe Right("IATA city code")
+  }
+
+  trait TraitWithVar {
+    var counter: Int = 0
+
+    @description("Do the thing")
+    def doThing(x: Int): String
+  }
+
+  class TraitWithVarImpl extends TraitWithVar {
+    override def doThing(x: Int): String = s"did:$x"
+  }
+
+  it should "skip var accessors (getter and setter) and derive only the annotated method" in {
+    val tools = AgentTools.derive[TraitWithVar](new TraitWithVarImpl)
+    tools.map(_.name) shouldBe Seq("doThing")
+  }
+
   behavior of "AgentTools.deriveF"
 
   it should "derive tools whose execute returns F[String]" in {

--- a/core/src/test/scala/sttp/ai/core/agent/AgentToolEnsureObjectTypeSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentToolEnsureObjectTypeSpec.scala
@@ -10,7 +10,28 @@ class AgentToolEnsureObjectTypeSpec extends AnyFlatSpec with Matchers {
   behavior of "AgentTool.ensureObjectType"
 
   it should "replace a boolean schema (MCP's `true` = any input) with a minimal object schema" in {
-    AgentTool.ensureObjectType(Json.True) shouldBe parse("""{"type":"object"}""").getOrElse(fail("invalid json"))
+    AgentTool.ensureObjectType(Json.True) shouldBe parse("""{"type":"object","properties":{}}""").getOrElse(fail("invalid json"))
+  }
+
+  it should "add empty properties to a propertyless object schema" in {
+    val schema = parse("""{"type":"object"}""").getOrElse(fail("invalid json"))
+    AgentTool.ensureObjectType(schema) shouldBe parse("""{"type":"object","properties":{}}""").getOrElse(fail("invalid json"))
+  }
+
+  it should "not inject properties next to a $ref, combinator, or discriminator" in {
+    val refRoot = parse("""{"type":"object","$ref":"#/$defs/X"}""").getOrElse(fail("invalid json"))
+    AgentTool.ensureObjectType(refRoot) shouldBe refRoot
+    val anyOfRoot = parse("""{"type":"object","anyOf":[{"type":"string"}]}""").getOrElse(fail("invalid json"))
+    AgentTool.ensureObjectType(anyOfRoot) shouldBe anyOfRoot
+    val discRoot = parse("""{"type":"object","discriminator":{"propertyName":"kind"},"oneOf":[]}""").getOrElse(fail("invalid json"))
+    AgentTool.ensureObjectType(discRoot) shouldBe discRoot
+  }
+
+  it should "not inject properties into a map-like object with schema-form or true additionalProperties" in {
+    val mapLike = parse("""{"type":"object","additionalProperties":{"type":"string"}}""").getOrElse(fail("invalid json"))
+    AgentTool.ensureObjectType(mapLike) shouldBe mapLike
+    val freeForm = parse("""{"type":"object","additionalProperties":true}""").getOrElse(fail("invalid json"))
+    AgentTool.ensureObjectType(freeForm) shouldBe freeForm
   }
 
   it should "add a `type: object` field to an object schema that omits it" in {

--- a/docs/agents/tools.md
+++ b/docs/agents/tools.md
@@ -67,6 +67,7 @@ The rules:
 - Each method must carry a `@description` annotation (`sttp.tapir.Schema.annotations.description`) — it becomes the tool description. Parameter-level `@description` annotations become property descriptions.
 - Methods must return `String`. For effectful services use `AgentTools.deriveF[F, MyService]` with methods returning `F[String]`.
 - Invalid shapes — a missing `@description`, overloads, default parameter values, multiple/`using` parameter lists, type parameters, or a parameter type without given `Schema`/`Decoder`/`Encoder` instances — are compile-time errors.
+- All inherited public methods must conform to these rules — there is no per-method exclusion mechanism — so a service trait should not mix tool methods with unrelated public methods (e.g. extending `AutoCloseable` won't work).
 
 Derivation is **Scala 3 only**: on Scala 2.13, define tools individually with `AgentTool.fromFunction` as shown above.
 

--- a/docs/agents/tools.md
+++ b/docs/agents/tools.md
@@ -35,6 +35,41 @@ The `derives io.circe.Codec.AsObject, Schema` clause automatically generates the
 
 See [JSON Schemas: structured outputs & tools](../other/json-schemas.md) for how schema derivation works and how to customise it.
 
+## Deriving tool sets from a service trait
+
+On Scala 3, a whole tool set can be derived from a service trait's methods with `AgentTools.derive` — one tool per public method, without defining an input case class per tool:
+
+```scala mdoc:compile-only
+//> using dep com.softwaremill.sttp.ai::openai:@VERSION@
+
+import sttp.ai.core.agent.*
+import sttp.tapir.Schema.annotations.description
+
+trait WeatherService:
+  @description("Get the current weather for a city")
+  def currentWeather(@description("City name") city: String): String
+
+  @description("Get a multi-day forecast")
+  def forecast(city: String, days: Int): String
+
+class WeatherServiceImpl extends WeatherService:
+  def currentWeather(city: String): String = s"Sunny in $city"
+  def forecast(city: String, days: Int): String = s"$days days of sun in $city"
+
+val tools = AgentTools.derive[WeatherService](WeatherServiceImpl())
+// two AgentTools: "currentWeather" and "forecast"
+```
+
+The rules:
+
+- Every public method with a single (possibly empty) parameter list becomes a tool; methods inherited from parent traits are included. Parameterless accessors (`def foo: String`, `val`s) are skipped.
+- The tool name is the method name; JSON schema properties are the parameter names, with types taken from each parameter's tapir `Schema`. `Option` parameters become optional properties.
+- Each method must carry a `@description` annotation (`sttp.tapir.Schema.annotations.description`) — it becomes the tool description. Parameter-level `@description` annotations become property descriptions.
+- Methods must return `String`. For effectful services use `AgentTools.deriveF[F, MyService]` with methods returning `F[String]`.
+- Invalid shapes — a missing `@description`, overloads, default parameter values, multiple/`using` parameter lists, type parameters, or a parameter type without given `Schema`/`Decoder`/`Encoder` instances — are compile-time errors.
+
+Derivation is **Scala 3 only**: on Scala 2.13, define tools individually with `AgentTool.fromFunction` as shown above.
+
 ## Agent Result
 
 ```scala

--- a/docs/agents/tools.md
+++ b/docs/agents/tools.md
@@ -62,12 +62,13 @@ val tools = AgentTools.derive[WeatherService](WeatherServiceImpl())
 
 The rules:
 
-- Every public method with a single (possibly empty) parameter list becomes a tool; methods inherited from parent traits are included. Parameterless accessors (`def foo: String`, `val`s) are skipped.
-- The tool name is the method name; JSON schema properties are the parameter names, with types taken from each parameter's tapir `Schema`. `Option` parameters become optional properties.
-- Each method must carry a `@description` annotation (`sttp.tapir.Schema.annotations.description`) — it becomes the tool description. Parameter-level `@description` annotations become property descriptions.
-- Methods must return `String`. For effectful services use `AgentTools.deriveF[F, MyService]` with methods returning `F[String]`.
-- Invalid shapes — a missing `@description`, overloads, default parameter values, multiple/`using` parameter lists, type parameters, or a parameter type without given `Schema`/`Decoder`/`Encoder` instances — are compile-time errors.
+- Every public method with a single (possibly empty) parameter list becomes a tool; methods inherited from parent traits are included. Parameterless accessors (`def foo: String`, `val`s, `var`s) are skipped — unless a parameterless `def` carries `@description`, which is a compile error (add `()` to expose it as a tool).
+- The tool name is the method name; JSON schema properties are the parameter names, with types taken from each parameter's tapir `Schema`. `Option` parameters become optional properties. Case-class parameters work out of the box (given their own `Schema`/`Codec` instances); their schemas are referenced via `$defs`.
+- Each method must carry a `@description` annotation (`sttp.tapir.Schema.annotations.description`) — it becomes the tool description. Parameter-level `@description` annotations become property descriptions. The annotation argument can be a string literal or any compile-time constant string (e.g. a `final val`).
+- Methods must return `String`. For effectful services use `AgentTools.deriveF[F, MyService]` with methods returning `F[String]` (covariantly narrowed return types, e.g. `Some[String]` for `F = Option`, conform).
+- Invalid shapes — a missing `@description`, overloads, default parameter values, multiple/`using` parameter lists, type parameters, by-name or vararg parameters, or a parameter type without given `Schema`/`Decoder`/`Encoder` instances — are compile-time errors.
 - All inherited public methods must conform to these rules — there is no per-method exclusion mechanism — so a service trait should not mix tool methods with unrelated public methods (e.g. extending `AutoCloseable` won't work).
+- Duplicate tool names are rejected within one trait (no overloads), but when combining tool sets derived from several traits, keeping names unique across the combined set is the caller's responsibility.
 
 Derivation is **Scala 3 only**: on Scala 2.13, define tools individually with `AgentTool.fromFunction` as shown above.
 

--- a/gemini/src/test/scala/sttp/ai/gemini/agent/GeminiAgentBackendSpec.scala
+++ b/gemini/src/test/scala/sttp/ai/gemini/agent/GeminiAgentBackendSpec.scala
@@ -75,7 +75,7 @@ class GeminiAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
     }
 
     newBackend(Seq(tool)).convertedTools.head match {
-      case Tool.Function(_, _, parameters) => parameters shouldBe parse("""{"type":"object"}""").value
+      case Tool.Function(_, _, parameters) => parameters shouldBe parse("""{"type":"object","properties":{}}""").value
       case other                           => fail(s"expected Tool.Function, got $other")
     }
   }
@@ -259,8 +259,9 @@ class GeminiAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
     }
 
     newBackend(Seq(tool)).convertedTools.head match {
-      case Tool.Function(_, _, parameters) => parameters shouldBe Json.obj("type" -> Json.fromString("object"))
-      case other                           => fail(s"expected Tool.Function, got $other")
+      case Tool.Function(_, _, parameters) =>
+        parameters shouldBe Json.obj("type" -> Json.fromString("object"), "properties" -> Json.obj())
+      case other => fail(s"expected Tool.Function, got $other")
     }
   }
 

--- a/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/SchemaSupport.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/SchemaSupport.scala
@@ -151,9 +151,10 @@ object SchemaSupport {
     * bare `{}`) would otherwise reach OpenAI missing fields strict mode always requires (`type`, `properties`, `additionalProperties`), and
     * be rejected at request time.
     *
-    * The guard mirrors the folder's own trigger condition exactly: a schema that already has `"properties"` or `"type"` is left alone even
-    * if `additionalProperties` ended up absent, since that can be a deliberate choice (e.g. the folder's discriminated-union skip) rather
-    * than the degenerate case this handles.
+    * A root that already has `"type": "object"` but no `"properties"` (e.g. an argument-less tool whose schema is exactly
+    * `{"type": "object"}`) gets an empty `"properties"` added too: strict mode requires the key to be present on every object. Roots with
+    * `"properties"` are left alone even if `additionalProperties` ended up absent, since that can be a deliberate choice (e.g. the folder's
+    * discriminated-union skip) rather than the degenerate case this handles.
     */
   private def ensureStrictObjectRoot(json: Json): Json =
     json.asObject match {
@@ -161,6 +162,12 @@ object SchemaSupport {
         Json.fromJsonObject(
           obj
             .add("type", Json.fromString("object"))
+            .add("properties", Json.obj())
+            .add("additionalProperties", Json.fromBoolean(false))
+        )
+      case Some(obj) if !obj.contains("properties") && obj("type").contains(Json.fromString("object")) =>
+        Json.fromJsonObject(
+          obj
             .add("properties", Json.obj())
             .add("additionalProperties", Json.fromBoolean(false))
         )

--- a/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/SchemaSupport.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/SchemaSupport.scala
@@ -22,7 +22,11 @@ object SchemaSupport {
     * Only apply this when the caller actually requested strict mode (`strict: true`); everything else should get a faithful encoding (see
     * [[schemaCodec]]).
     */
-  def normalizeForStrict(schemaJson: Json): Json = ensureStrictObjectRoot(schemaJson.foldWith(schemaFolder))
+  def normalizeForStrict(schemaJson: Json): Json =
+    // The boolean schema form `true`/`false` ("any input" / "no input", an MCP idiom) never reaches the folder as an
+    // object; normalize it to the minimal object schema first so strict mode gets type/properties/additionalProperties.
+    if (schemaJson.isBoolean) normalizeForStrict(Json.obj("type" -> Json.fromString("object")))
+    else ensureStrictObjectRoot(schemaJson.foldWith(schemaFolder))
 
   /** Normalizes an apispec `Schema` to OpenAI's strict-mode rules. See [[normalizeForStrict(Json)]]. */
   def normalizeForStrict(schema: Schema): Json = normalizeForStrict(encoderSchema(schema).deepDropNullValues)
@@ -102,7 +106,19 @@ object SchemaSupport {
       val remove = addlPropsRemove ++ requiredRemove
       val fields = addlPropsAdd ++ requiredAdd ++ state.fields.filterNot { case (k, _) => remove.contains(k) }
 
-      Json.fromFields(fields)
+      // Strict mode requires `properties` on every object, not just the root (a zero-field case class in $defs is an
+      // object too). Repair only plain objects: schemas whose shape lives elsewhere ($ref, combinators, a
+      // discriminator, or an explicit non-false additionalProperties for map-like objects) are left alone - injecting
+      // an empty `properties` there would silently narrow them (a map-like root should keep failing loudly, since
+      // strict mode cannot express free-form objects at all).
+      val isPlainPropertylessObject =
+        value("type").contains(Json.fromString("object")) &&
+          !value.contains("properties") &&
+          !Seq("$ref", "oneOf", "anyOf", "allOf", "discriminator").exists(value.contains) &&
+          !value("additionalProperties").exists(ap => !ap.isBoolean || ap.asBoolean.contains(true))
+      val repairedFields = if (isPlainPropertylessObject) fields :+ ("properties" -> Json.obj()) else fields
+
+      Json.fromFields(repairedFields)
     }
   }
 
@@ -146,28 +162,22 @@ object SchemaSupport {
     }
 
   /** `normalizeForStrict` is only ever called on a schema OpenAI itself requires to be an object (a tool's `parameters`, or a
-    * structured-output schema's root) — but the folder above only adds `additionalProperties: false`/`properties` to an object when it sees
-    * a `"properties"` or `"type": "object"` key to trigger on. A schema with NEITHER (e.g. a genuinely argument-less tool advertising a
-    * bare `{}`) would otherwise reach OpenAI missing fields strict mode always requires (`type`, `properties`, `additionalProperties`), and
-    * be rejected at request time.
+    * structured-output schema's root) - but the folder repairs `properties` only on objects that already carry `"type": "object"`. A
+    * degenerate root with NEITHER `type` nor `properties` (e.g. a genuinely argument-less tool advertising a bare `{}`) would otherwise
+    * reach OpenAI missing the fields strict mode always requires, and be rejected at request time.
     *
-    * A root that already has `"type": "object"` but no `"properties"` (e.g. an argument-less tool whose schema is exactly
-    * `{"type": "object"}`) gets an empty `"properties"` added too: strict mode requires the key to be present on every object. Roots with
-    * `"properties"` are left alone even if `additionalProperties` ended up absent, since that can be a deliberate choice (e.g. the folder's
-    * discriminated-union skip) rather than the degenerate case this handles.
+    * The repair is skipped for roots whose shape is defined elsewhere (`$ref`, combinators, a discriminator): stamping
+    * `type`/`properties`/`additionalProperties` next to those would silently constrain the schema to `{}` instead of surfacing the
+    * incompatibility.
     */
   private def ensureStrictObjectRoot(json: Json): Json =
     json.asObject match {
-      case Some(obj) if !obj.contains("properties") && !obj.contains("type") =>
+      case Some(obj)
+          if !obj.contains("properties") && !obj.contains("type") &&
+            !Seq("$ref", "oneOf", "anyOf", "allOf", "discriminator").exists(obj.contains) =>
         Json.fromJsonObject(
           obj
             .add("type", Json.fromString("object"))
-            .add("properties", Json.obj())
-            .add("additionalProperties", Json.fromBoolean(false))
-        )
-      case Some(obj) if !obj.contains("properties") && obj("type").contains(Json.fromString("object")) =>
-        Json.fromJsonObject(
-          obj
             .add("properties", Json.obj())
             .add("additionalProperties", Json.fromBoolean(false))
         )

--- a/openai/src/test/scala/sttp/ai/openai/openai/requests/completions/chat/SchemaSupportSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/requests/completions/chat/SchemaSupportSpec.scala
@@ -113,6 +113,12 @@ class SchemaSupportSpec extends AnyFlatSpec with Matchers with EitherValues {
     result shouldBe expected
   }
 
+  it should "add empty properties to an object root that has a type but no properties" in {
+    val result = normalize("""{"type":"object"}""")
+    val expected = parse("""{"type":"object","properties":{},"additionalProperties":false}""").value
+    result shouldBe expected
+  }
+
   it should "still skip additionalProperties on discriminated unions" in {
     val result = normalize(
       """{"type":"object",

--- a/openai/src/test/scala/sttp/ai/openai/openai/requests/completions/chat/SchemaSupportSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/requests/completions/chat/SchemaSupportSpec.scala
@@ -119,6 +119,44 @@ class SchemaSupportSpec extends AnyFlatSpec with Matchers with EitherValues {
     result shouldBe expected
   }
 
+  it should "not stamp properties onto a propertyless discriminated-union root" in {
+    val rawSchema =
+      """{"type":"object",
+        |"discriminator":{"propertyName":"kind"},
+        |"oneOf":[{"type":"object","properties":{"kind":{"type":"string"},"a":{"type":"string"}},"required":["kind","a"]}]}""".stripMargin
+    val result = normalize(rawSchema)
+    result.hcursor.downField("properties").focus shouldBe None
+    result.hcursor.downField("additionalProperties").focus shouldBe None
+  }
+
+  it should "add empty properties to a propertyless nested object, not just the root" in {
+    val rawSchema =
+      """{"type":"object",
+        |"properties":{"a":{"$ref":"#/$defs/Empty"}},
+        |"required":["a"],
+        |"$defs":{"Empty":{"title":"Empty","type":"object"}}}""".stripMargin
+    val result = normalize(rawSchema)
+    val empty = result.hcursor.downField("$defs").downField("Empty")
+    empty.downField("properties").focus shouldBe Some(Json.obj())
+    empty.get[Boolean]("additionalProperties") shouldBe Right(false)
+  }
+
+  it should "normalize the boolean schema form to a strict-valid object" in {
+    normalize("true") shouldBe parse("""{"type":"object","properties":{},"additionalProperties":false}""").value
+  }
+
+  it should "leave a $ref-only root untouched instead of constraining it to an empty object" in {
+    val refRoot = """{"$ref":"#/$defs/X"}"""
+    normalize(refRoot) shouldBe parse(refRoot).value
+  }
+
+  it should "not silently narrow a map-like object to an empty one" in {
+    val result = normalize("""{"type":"object","additionalProperties":{"type":"string"}}""")
+    // additionalProperties clobbering to false is pre-existing strict-mode behavior; the important part is that no
+    // empty `properties` appears, so OpenAI still rejects the schema loudly instead of accepting a {}-only object
+    result.hcursor.downField("properties").focus shouldBe None
+  }
+
   it should "still skip additionalProperties on discriminated unions" in {
     val result = normalize(
       """{"type":"object",


### PR DESCRIPTION
## AgentTools.derive: tool sets from service traits (Scala 3)

Adds `AgentTools.derive[S]` / `AgentTools.deriveF[F, S]` — a Scala 3 macro deriving a whole `Seq[AgentTool]` from a service trait's public methods, without an input case class per tool:

```scala
import sttp.tapir.Schema.annotations.description

trait WeatherService:
  @description("Get the current weather for a city")
  def currentWeather(@description("City name") city: String): String

  @description("Get a multi-day forecast")
  def forecast(city: String, days: Int): String

val tools = AgentTools.derive[WeatherService](impl) // two AgentTools

How it works

- One tool per public method with a single (possibly empty) parameter list; inherited trait methods included; accessors/vars skipped (a @description-annotated parameterless def is a compile error, not a silent skip); tools sorted by name. Case-class parameters render into $defs (named root schema).
- Each tool's input type is the tuple of the method's parameter types; the macro composes summoned per-parameter tapir Schemas and circe Decoder/Encoders, then delegates to the existing AgentTool.fromFunctionF — schema rendering goes through the same TapirSchemaToJsonSchema path as hand-built tools.
- @description (tapir's annotation) is required on methods (compile error otherwise, with fallback through overridden symbols so derive(impl) with an inferred impl-class type works), optional on parameters. Option parameters become non-required properties.
- Invalid shapes are compile errors: overloads, default parameter values, multiple/using parameter lists, method type parameters, by-name/vararg parameters, wrong return type, missing given instances. @description accepts any compile-time constant string.
- deriveF[F, S] for effectful services (F[String]-returning methods; covariantly narrowed return types conform).
- Includes a small strict-mode fix in the openai module: object roots with type but no properties (zero-arg tools) now get properties: {} added, as OpenAI strict mode requires.

Scope / compatibility

- Scala 3 only (documented); Scala 2.13 keeps using AgentTool.fromFunction. Additive, non-breaking.
- 28 new tests (AgentToolsDeriveSpec, AgentToolsDeriveErrorsSpec incl. 12 compile-error cases via typeCheckErrors, plus a strict-mode SchemaSupportSpec case); docs section added to docs/agents/tools.md (mdoc-compiled).