### PR TITLE
Feature/agent conversation history

### DIFF
--- a/claude/src/main/scala/sttp/ai/claude/agent/ClaudeAgent.scala
+++ b/claude/src/main/scala/sttp/ai/claude/agent/ClaudeAgent.scala
@@ -16,9 +16,12 @@ private[claude] class ClaudeAgentBackend[F[_]](
     modelForIteration: IterationInfo => ClaudeModel,
     val tools: Seq[AgentTool[F, _]],
     val systemPrompt: Option[String],
-    responseSchema: Option[ResponseSchema[_]]
+    responseSchema: Option[ResponseSchema[_]],
+    maxTokens: Option[Int] = None
 )(implicit monad: sttp.monad.MonadError[F])
     extends AgentBackend[F] {
+
+  private val effectiveMaxTokens: Int = maxTokens.getOrElse(ClaudeAgentBackend.DefaultMaxTokens)
 
   private[claude] val convertedTools: Seq[Tool] = tools.map(convertTool)
 
@@ -77,7 +80,7 @@ private[claude] class ClaudeAgentBackend[F[_]](
     val request = MessageRequest(
       model = modelForIteration(iterationInfo).value,
       messages = messages.toList,
-      maxTokens = 4096,
+      maxTokens = effectiveMaxTokens,
       system = systemPrompt,
       tools = if (includeTools && convertedTools.nonEmpty) Some(convertedTools.toList) else None,
       outputConfig = outputConfig
@@ -123,6 +126,10 @@ private[claude] class ClaudeAgentBackend[F[_]](
     }
 }
 
+private[claude] object ClaudeAgentBackend {
+  val DefaultMaxTokens: Int = 4096
+}
+
 object ClaudeAgent {
 
   /** Entry point: `ClaudeAgent.builder[F](client, model)`. The indirection lets `M` be inferred while `F` is given explicitly. */
@@ -142,7 +149,7 @@ object ClaudeAgent {
         monad: sttp.monad.MonadError[F]
     ): AgentBuilder[F, M, String, String] =
       AgentBuilder[F, M](config =>
-        new ClaudeAgentBackend[F](client, modelForIteration, config.userTools, config.systemPrompt, config.responseSchema)
+        new ClaudeAgentBackend[F](client, modelForIteration, config.userTools, config.systemPrompt, config.responseSchema, config.maxTokens)
       )
 
     def apply(client: ClaudeClient, modelName: String)(implicit

--- a/claude/src/test/scala/sttp/ai/claude/agent/ClaudeAgentBackendSpec.scala
+++ b/claude/src/test/scala/sttp/ai/claude/agent/ClaudeAgentBackendSpec.scala
@@ -117,11 +117,11 @@ class ClaudeAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
       |  "usage": {"input_tokens": 10, "output_tokens": 20}
       |}""".stripMargin
 
-  private def captureRequestBody(includeTools: Boolean): String = {
+  private def captureRequestBody(includeTools: Boolean, maxTokens: Option[Int] = None): String = {
     val schema = parse(rawSchema).value.as[Schema](sttp.apispec.circe.schemaDecoder).value
     val tool = AgentTool.dynamic("create-event", "Creates an event", schema)(_ => "ok")
     val client = ClaudeClient(ClaudeConfig(apiKey = "test-key"))
-    val backend = new ClaudeAgentBackend[Identity](client, _ => ClaudeModel.ClaudeHaiku4_5, Seq(tool), None, None)(IdentityMonad)
+    val backend = new ClaudeAgentBackend[Identity](client, _ => ClaudeModel.ClaudeHaiku4_5, Seq(tool), None, None, maxTokens)(IdentityMonad)
 
     val captured = new AtomicReference[GenericRequest[_, _]](null)
     val httpStub = DefaultSyncBackend.stub.whenAnyRequest.thenRespondF { request =>
@@ -141,6 +141,16 @@ class ClaudeAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
 
   it should "omit tools from the request body when includeTools is false" in {
     captureRequestBody(includeTools = false) should not include "\"tools\""
+  }
+
+  it should "send max_tokens 4096 by default" in {
+    val bodyJson = parse(captureRequestBody(includeTools = true)).value
+    bodyJson.hcursor.downField("max_tokens").as[Int] shouldBe Right(4096)
+  }
+
+  it should "send the configured max_tokens" in {
+    val bodyJson = parse(captureRequestBody(includeTools = true, maxTokens = Some(8192))).value
+    bodyJson.hcursor.downField("max_tokens").as[Int] shouldBe Right(8192)
   }
 
   it should "resolve the model per iteration via modelForIteration" in {

--- a/core/src/main/scala/sttp/ai/core/agent/Agent.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/Agent.scala
@@ -13,7 +13,15 @@ trait Agent[F[_], In, Out] { self =>
 
   protected implicit def monad: MonadError[F]
 
-  def run(in: In)(backend: Backend[F]): F[AgentResult[Either[AgentFailure, Out]]]
+  /** Runs the agent loop as a fresh conversation seeded only with `in`. */
+  def run(in: In)(backend: Backend[F]): F[AgentResult[Either[AgentFailure, Out]]] =
+    run(in, ConversationHistory.empty)(backend)
+
+  /** Runs the agent loop continuing an existing conversation: `history` seeds the conversation and `in` (rendered by the input renderer) is
+    * appended as the next user message. Pass [[AgentResult.history]] from a previous run to keep talking with full context; the returned
+    * result's `history` extends the seed and can be fed back in again.
+    */
+  def run(in: In, history: ConversationHistory)(backend: Backend[F]): F[AgentResult[Either[AgentFailure, Out]]]
 
   /** Typed handoff: runs `this`, then feeds its `Out` to `next` as a fresh conversation (rendered by `next`'s input renderer). Compiles
     * only when this agent's output type is `next`'s input type. If `this` fails (`Left`), `next` never runs. Metadata is aggregated:
@@ -21,13 +29,15 @@ trait Agent[F[_], In, Out] { self =>
     * `ToolCallRecord.iteration` stays stage-local. If `next` raises an error in `F`'s error channel, it propagates as a plain error and
     * `this` stage's accumulated metadata (usage, tool calls) is not reported in that case. Interceptors are also stage-local: each agent
     * runs with its own configured interceptors, so e.g. a budget interceptor on `next` does not observe this stage's token spend.
+    * Conversation histories are stage-local too: a seed history passed to `run` seeds only `this` stage, and the combined result's
+    * `history` is that of the last stage that ran.
     */
   def andThen[Out2](next: Agent[F, Out, Out2]): Agent[F, In, Out2] = {
     val m = monad
     new Agent[F, In, Out2] {
       protected implicit def monad: MonadError[F] = m
-      def run(in: In)(backend: Backend[F]): F[AgentResult[Either[AgentFailure, Out2]]] =
-        self.run(in)(backend).flatMap { first =>
+      def run(in: In, history: ConversationHistory)(backend: Backend[F]): F[AgentResult[Either[AgentFailure, Out2]]] =
+        self.run(in, history)(backend).flatMap { first =>
           first.finalAnswer match {
             case Left(failure) =>
               m.unit(
@@ -37,7 +47,8 @@ trait Agent[F[_], In, Out] { self =>
                   first.toolCalls,
                   first.finishReason,
                   first.usage,
-                  first.llmCalls
+                  first.llmCalls,
+                  first.history
                 )
               )
             case Right(out) =>
@@ -48,7 +59,8 @@ trait Agent[F[_], In, Out] { self =>
                   first.toolCalls ++ second.toolCalls,
                   second.finishReason,
                   first.usage + second.usage,
-                  first.llmCalls ++ second.llmCalls
+                  first.llmCalls ++ second.llmCalls,
+                  second.history
                 )
               }
           }
@@ -61,9 +73,9 @@ trait Agent[F[_], In, Out] { self =>
     val m = monad
     new Agent[F, In, Out2] {
       protected implicit def monad: MonadError[F] = m
-      def run(in: In)(backend: Backend[F]): F[AgentResult[Either[AgentFailure, Out2]]] =
-        self.run(in)(backend).map { res =>
-          AgentResult(res.finalAnswer.map(f), res.iterations, res.toolCalls, res.finishReason, res.usage, res.llmCalls)
+      def run(in: In, history: ConversationHistory)(backend: Backend[F]): F[AgentResult[Either[AgentFailure, Out2]]] =
+        self.run(in, history)(backend).map { res =>
+          AgentResult(res.finalAnswer.map(f), res.iterations, res.toolCalls, res.finishReason, res.usage, res.llmCalls, res.history)
         }
     }
   }
@@ -73,8 +85,8 @@ trait Agent[F[_], In, Out] { self =>
     val m = monad
     new Agent[F, In2, Out] {
       protected implicit def monad: MonadError[F] = m
-      def run(in: In2)(backend: Backend[F]): F[AgentResult[Either[AgentFailure, Out]]] =
-        self.run(f(in))(backend)
+      def run(in: In2, history: ConversationHistory)(backend: Backend[F]): F[AgentResult[Either[AgentFailure, Out]]] =
+        self.run(f(in), history)(backend)
     }
   }
 }

--- a/core/src/main/scala/sttp/ai/core/agent/AgentBuilder.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentBuilder.scala
@@ -25,6 +25,9 @@ final class AgentBuilder[F[_], M <: AIModel, In, Out] private (
 
   def maxIterations(value: Int): AgentBuilder[F, M, In, Out] = withConfig(config.copy(maxIterations = value))
 
+  /** Caps the tokens the model may generate per LLM call. Unset, each provider's default applies (Claude/Gemini: 4096, OpenAI: no cap). */
+  def maxTokens(value: Int): AgentBuilder[F, M, In, Out] = withConfig(config.copy(maxTokens = Some(value)))
+
   def systemPrompt(buildSystemPrompt: SystemPromptParameters => String): AgentBuilder[F, M, In, Out] =
     withConfig(config.copy(systemPromptBuilder = Some(buildSystemPrompt)))
 

--- a/core/src/main/scala/sttp/ai/core/agent/AgentConfig.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentConfig.scala
@@ -2,8 +2,13 @@ package sttp.ai.core.agent
 
 import sttp.ai.core.agent.AgentConfig.SystemPromptParameters
 
+/** @param maxTokens
+  *   caps the tokens the model may generate per LLM call. `None` (the default) keeps each provider's default behavior: Claude and Gemini
+  *   send 4096, OpenAI sends no cap. When a response hits the cap the loop ends with [[FinishReason.TokenLimit]].
+  */
 case class AgentConfig[F[_]](
     maxIterations: Int = 10,
+    maxTokens: Option[Int] = None,
     systemPromptBuilder: Option[SystemPromptParameters => String] = Some(AgentConfig.buildSystemPrompt),
     userTools: Seq[AgentTool[F, _]] = Seq.empty[AgentTool[F, _]],
     exceptionHandler: ExceptionHandler = ExceptionHandler.default,

--- a/core/src/main/scala/sttp/ai/core/agent/AgentResult.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentResult.scala
@@ -30,13 +30,20 @@ final case class ToolCallRecord(
     iteration: Int
 )
 
+/** @param history
+  *   the full conversation accumulated by the run — the seed history passed to `run` (if any), the rendered user message, assistant
+  *   responses, tool results, and the final assistant answer. Feed it back into [[Agent.run]] together with a new user message to continue
+  *   the conversation. Per-request iteration markers and forced-finish instructions are transient and not part of it; tool calls from a
+  *   forced final response are not executed and thus not recorded.
+  */
 final case class AgentResult[T](
     finalAnswer: T,
     iterations: Int,
     toolCalls: Seq[ToolCallRecord],
     finishReason: FinishReason,
     usage: TokenUsage = TokenUsage.Zero,
-    llmCalls: Seq[LlmCallUsage] = Seq.empty
+    llmCalls: Seq[LlmCallUsage] = Seq.empty,
+    history: ConversationHistory = ConversationHistory.empty
 )
 
 sealed trait AgentFailure {

--- a/core/src/main/scala/sttp/ai/core/agent/LoopAgent.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/LoopAgent.scala
@@ -18,8 +18,8 @@ private[agent] class LoopAgent[F[_], In, Out](
 
   private val interceptor: AgentInterceptor[F] = AgentInterceptor.compose(config.interceptors)
 
-  def run(in: In)(backend: Backend[F]): F[AgentResult[Either[AgentFailure, Out]]] =
-    runRaw(renderInput(in))(backend).map { res =>
+  def run(in: In, history: ConversationHistory)(backend: Backend[F]): F[AgentResult[Either[AgentFailure, Out]]] =
+    runRaw(renderInput(in), history)(backend).map { res =>
       val parsed: Either[AgentFailure, Out] = res.finishReason match {
         case FinishReason.NaturalStop =>
           parseOutput(res.finalAnswer).left.map(e => AgentParseError(res.finalAnswer, e))
@@ -29,13 +29,14 @@ private[agent] class LoopAgent[F[_], In, Out](
         case FinishReason.TokenLimit | FinishReason.Error(_) =>
           Left(AgentIncomplete(res.finalAnswer, res.finishReason, parseError = None))
       }
-      AgentResult(parsed, res.iterations, res.toolCalls, res.finishReason, res.usage, res.llmCalls)
+      AgentResult(parsed, res.iterations, res.toolCalls, res.finishReason, res.usage, res.llmCalls, res.history)
     }
 
   private def runRaw(
-      initialPrompt: String
+      initialPrompt: String,
+      seedHistory: ConversationHistory
   )(backend: Backend[F]): F[AgentResult[String]] = {
-    val initialHistory = ConversationHistory.withInitialPrompt(initialPrompt)
+    val initialHistory = seedHistory.addUserPrompt(initialPrompt)
 
     def loop(
         history: ConversationHistory,
@@ -48,7 +49,7 @@ private[agent] class LoopAgent[F[_], In, Out](
       // below always returns at iteration == maxIterations - 1, so the loop never recurses past it.
       if (iteration >= config.maxIterations) {
         monad.unit(
-          AgentResult(extractFinalAnswer(history), iteration, records, FinishReason.MaxIterations, usage, llmCalls)
+          AgentResult(extractFinalAnswer(history), iteration, records, FinishReason.MaxIterations, usage, llmCalls, history)
         )
       } else {
         val decision = interceptor.decide(AgentRunState(iteration, config.maxIterations, usage, llmCalls))
@@ -100,9 +101,17 @@ private[agent] class LoopAgent[F[_], In, Out](
         val newUsage = usage + callUsage
         val newLlmCalls = llmCalls :+ LlmCallUsage(response.model, callUsage)
 
+        // The final assistant response is recorded so AgentResult.history is a complete, replayable transcript. Spurious
+        // tool calls from a final response are not executed, so they are not recorded either (an unanswered tool call
+        // would make the history invalid as a seed for a follow-up run). Empty text is skipped for the same reason.
+        def finalHistory: ConversationHistory =
+          if (response.textContent.nonEmpty) history.addAssistantResponse(response.textContent, Seq.empty) else history
+
         if (response.stopReason == StopReason.MaxTokens) {
           monad.unit(
-            Finished(AgentResult(response.textContent, iteration + 1, records, FinishReason.TokenLimit, newUsage, newLlmCalls))
+            Finished(
+              AgentResult(response.textContent, iteration + 1, records, FinishReason.TokenLimit, newUsage, newLlmCalls, finalHistory)
+            )
           )
         } else if (isFinalIteration) {
           // Tools were not offered on the final iteration, so any tool calls in the response are spurious and must not
@@ -110,11 +119,13 @@ private[agent] class LoopAgent[F[_], In, Out](
           val finalAnswer = if (response.textContent.nonEmpty) response.textContent else extractFinalAnswer(history)
           // MaxIterations takes precedence when the forced last iteration and a FinishNow coincide.
           val reason = if (isLastByCount) FinishReason.MaxIterations else forcedCause.getOrElse(FinishReason.MaxIterations)
-          monad.unit(Finished(AgentResult(finalAnswer, iteration + 1, records, reason, newUsage, newLlmCalls)))
+          monad.unit(Finished(AgentResult(finalAnswer, iteration + 1, records, reason, newUsage, newLlmCalls, finalHistory)))
         } else if (response.toolCalls.isEmpty) {
           // No tool calls - the agent has produced its final answer, so complete the loop.
           monad.unit(
-            Finished(AgentResult(response.textContent, iteration + 1, records, FinishReason.NaturalStop, newUsage, newLlmCalls))
+            Finished(
+              AgentResult(response.textContent, iteration + 1, records, FinishReason.NaturalStop, newUsage, newLlmCalls, finalHistory)
+            )
           )
         } else {
           val updatedHistory = history.addAssistantResponse(response.textContent, response.toolCalls)

--- a/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
@@ -616,6 +616,85 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
     budgetResult.finishReason shouldBe FinishReason.BudgetExceeded
   }
 
+  "AgentResult history" should "contain the full transcript including the final assistant answer" in {
+    val result = runLoop(
+      agentBuilder(
+        AgentResponse("", Seq(ToolCall(id = "call_1", toolName = "calculator", input = """{"a":5,"b":10}""")), StopReason.ToolUse),
+        AgentResponse("Done", Seq.empty, StopReason.EndTurn)
+      ).tools(calculatorTool)
+    )
+
+    result.history.entries shouldBe Seq(
+      ConversationEntry.UserPrompt("Test"),
+      ConversationEntry.AssistantResponse("", Seq(ToolCall("call_1", "calculator", """{"a":5,"b":10}"""))),
+      ConversationEntry.ToolResult("call_1", "calculator", "Result: 15.0"),
+      ConversationEntry.AssistantResponse("Done", Seq.empty)
+    )
+  }
+
+  it should "not record unexecuted tool calls from a forced final response" in {
+    val dummyTool = AgentTool.fromFunction(
+      "dummy",
+      "Dummy tool"
+    )((_: DummyInput) => "dummy result")
+
+    val result = runLoop(
+      agentBuilder(
+        AgentResponse("", Seq(ToolCall(id = "call_1", toolName = "dummy", input = "{}")), StopReason.ToolUse),
+        AgentResponse("forced answer", Seq(ToolCall(id = "call_2", toolName = "dummy", input = "{}")), StopReason.ToolUse)
+      ).maxIterations(2).tools(dummyTool)
+    )
+
+    result.finishReason shouldBe FinishReason.MaxIterations: Unit
+    result.history.entries.last shouldBe ConversationEntry.AssistantResponse("forced answer", Seq.empty): Unit
+    result.history.entries.collect { case ConversationEntry.AssistantResponse(_, calls) => calls }.flatten shouldBe
+      Seq(ToolCall("call_1", "dummy", "{}"))
+  }
+
+  it should "include the partial answer when the token limit is hit" in {
+    val result = runLoop(agentBuilder(AgentResponse("partial answer", Seq.empty, StopReason.MaxTokens)))
+
+    result.history.entries shouldBe Seq(
+      ConversationEntry.UserPrompt("Test"),
+      ConversationEntry.AssistantResponse("partial answer", Seq.empty)
+    )
+  }
+
+  "Agent run with history" should "seed the conversation and append the input as the next user message" in {
+    val stubBackend = new StubAgentBackend(Seq(AgentResponse("It is 42.", Seq.empty, StopReason.EndTurn)))
+    val seed = ConversationHistory.empty
+      .addUserPrompt("What is 2+2?")
+      .addAssistantResponse("4", Seq.empty)
+
+    val result = AgentBuilder[Identity, TestModel.type](_ => stubBackend)(IdentityMonad).build.run("Now times 10?", seed)(backend)
+
+    stubBackend.receivedHistories.head.entries shouldBe (seed.entries :+ ConversationEntry.UserPrompt("Now times 10?")): Unit
+    result.history.entries shouldBe (seed.entries ++ Seq(
+      ConversationEntry.UserPrompt("Now times 10?"),
+      ConversationEntry.AssistantResponse("It is 42.", Seq.empty)
+    ))
+  }
+
+  it should "continue a conversation from a previous result's history" in {
+    val stubBackend = new StubAgentBackend(
+      Seq(
+        AgentResponse("First answer", Seq.empty, StopReason.EndTurn),
+        AgentResponse("Second answer", Seq.empty, StopReason.EndTurn)
+      )
+    )
+    val agent = AgentBuilder[Identity, TestModel.type](_ => stubBackend)(IdentityMonad).build
+
+    val first = agent.run("First question")(backend)
+    val second = agent.run("Second question", first.history)(backend)
+
+    stubBackend.receivedHistories(1).entries shouldBe Seq(
+      ConversationEntry.UserPrompt("First question"),
+      ConversationEntry.AssistantResponse("First answer", Seq.empty),
+      ConversationEntry.UserPrompt("Second question")
+    ): Unit
+    second.history.entries.last shouldBe ConversationEntry.AssistantResponse("Second answer", Seq.empty)
+  }
+
   "AgentBuilder" should "append with addInterceptor() and replace with interceptors()" in {
     val a = AgentInterceptor.noop[Identity]
     val b = AgentInterceptor.noop[Identity]

--- a/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
@@ -584,15 +584,21 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
   "AgentBuilder" should "accumulate configuration into the built config" in {
     val config = agentBuilder()
       .maxIterations(7)
+      .maxTokens(8192)
       .systemPrompt("custom")
       .tools(calculatorTool)
       .exceptionHandler(ExceptionHandler.sendAllToLLM)
       .config
 
     config.maxIterations shouldBe 7
+    config.maxTokens shouldBe Some(8192)
     config.systemPrompt.value shouldBe "custom"
     config.userTools should contain only calculatorTool
     config.exceptionHandler shouldBe ExceptionHandler.sendAllToLLM
+  }
+
+  it should "leave maxTokens unset by default" in {
+    agentBuilder().config.maxTokens shouldBe None
   }
 
   it should "derive the default system prompt from the final maxIterations" in {

--- a/docs/agents/configuration.md
+++ b/docs/agents/configuration.md
@@ -8,6 +8,7 @@ Configure the agent with the fluent builder. Use `OpenAIAgent.builder[F]` / `Cla
 val agent = OpenAIAgent
   .synchronous(OpenAI.fromEnv, "gpt-4o-mini")
   .maxIterations(10)                               // Max reasoning steps
+  .maxTokens(8192)                                 // Optional per-call output-token cap
   .systemPrompt("Custom prompt")                   // Optional instructions
   .tools(tool1, tool2)                             // Your tools
   .deriveResponseSchema[T]                          // (fixes the agent's output type — see typed input and output in tools.md)
@@ -19,6 +20,11 @@ model to produce a final text answer instead of a tool call whose result would b
 `FinishReason.MaxIterations`). Tools are therefore only available for the first `maxIterations - 1` iterations — so with
 `maxIterations = 1` the agent never gets to use its tools. Set `maxIterations` at least one higher than the number of
 tool-using steps you expect the task to need.
+
+`maxTokens` caps the tokens the model may generate on each LLM call. When unset, each provider's default applies:
+Claude and Gemini send 4096, OpenAI sends no cap (the model's own maximum applies). For OpenAI it is sent as
+`max_completion_tokens`, which also works with reasoning models. When a response is cut off by the cap, the run ends
+with `FinishReason.TokenLimit` and the partial answer is returned as `Left(AgentIncomplete(...))`.
 
 The OpenAI factories additionally accept a `strictTools` flag (default `true`): when `true`, tool schemas are
 normalized for OpenAI's strict function calling (`additionalProperties: false`, all properties required, optional

--- a/docs/agents/quickstart.md
+++ b/docs/agents/quickstart.md
@@ -52,6 +52,39 @@ object BasicExample extends App {
 }
 ```
 
+## Multi-turn conversations
+
+Every `AgentResult` carries the full `ConversationHistory` of the run — the user message, assistant responses, tool calls and their results, and the final answer. To continue talking with full context, pass it back to `run` together with the next user message:
+
+```scala mdoc:compile-only
+//> using dep com.softwaremill.sttp.ai::openai:@VERSION@
+
+import sttp.ai.core.agent.*
+import sttp.ai.openai.OpenAI
+import sttp.ai.openai.agent.OpenAIAgent
+import sttp.ai.openai.requests.completions.chat.ChatRequestBody.ChatCompletionModel
+import sttp.client4.DefaultSyncBackend
+
+object ChatExample extends App {
+  val backend = DefaultSyncBackend()
+  try {
+    val agent = OpenAIAgent.synchronous(OpenAI.fromEnv, ChatCompletionModel.GPT4oMini).build
+
+    val first = agent.run("My name is Igor. What is 2+2?")(backend)
+    println(first.finalAnswer)
+
+    // seed the next run with the previous history: the model sees the whole conversation
+    val second = agent.run("Multiply that by 10, and remind me of my name.", first.history)(backend)
+    println(second.finalAnswer)
+
+    // second.history extends first.history — inspect it, persist it, or feed it into another run
+    second.history.entries.foreach(println)
+  } finally backend.close()
+}
+```
+
+A history can also be built (or restored, e.g. from a database) by hand via `ConversationHistory.empty.addUserPrompt(...).addAssistantResponse(...)` and passed as the seed of a fresh run.
+
 **For Claude:** Use `ClaudeAgent.synchronous(ClaudeConfig.fromEnv, ClaudeModel.ClaudeHaiku4_5.value)` instead.
 
 **For Gemini:** Use `GeminiAgent.synchronous(GeminiConfig.fromEnv, "gemini-2.5-flash")` — see [Gemini tool calling](../gemini/tool-calling.md) for a full example.

--- a/docs/agents/quickstart.md
+++ b/docs/agents/quickstart.md
@@ -70,7 +70,7 @@ object ChatExample extends App {
   try {
     val agent = OpenAIAgent.synchronous(OpenAI.fromEnv, ChatCompletionModel.GPT4oMini).build
 
-    val first = agent.run("My name is Igor. What is 2+2?")(backend)
+    val first = agent.run("My name is John Doe. What is 2+2?")(backend)
     println(first.finalAnswer)
 
     // seed the next run with the previous history: the model sees the whole conversation

--- a/gemini/src/main/scala/sttp/ai/gemini/agent/GeminiAgent.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/agent/GeminiAgent.scala
@@ -19,9 +19,12 @@ private[gemini] class GeminiAgentBackend[F[_]](
     modelForIteration: IterationInfo => GeminiModel,
     val tools: Seq[AgentTool[F, _]],
     val systemPrompt: Option[String],
-    responseSchema: Option[ResponseSchema[_]]
+    responseSchema: Option[ResponseSchema[_]],
+    maxTokens: Option[Int] = None
 )(implicit monad: sttp.monad.MonadError[F])
     extends AgentBackend[F] {
+
+  private val effectiveMaxTokens: Int = maxTokens.getOrElse(GeminiAgentBackend.DefaultMaxTokens)
 
   private[gemini] val convertedTools: Seq[Tool] = tools.map(convertTool)
 
@@ -91,7 +94,7 @@ private[gemini] class GeminiAgentBackend[F[_]](
           tools = if (includeTools && convertedTools.nonEmpty) Some(convertedTools.toList) else None,
           responseFormat = responseFormat,
           store = Some(false),
-          generationConfig = Some(GenerationConfig(maxOutputTokens = Some(4096)))
+          generationConfig = Some(GenerationConfig(maxOutputTokens = Some(effectiveMaxTokens)))
         )
 
         monad.flatMap(monad.map(client.createInteraction(request).send(backend))(_.body)) {
@@ -151,6 +154,10 @@ private[gemini] class GeminiAgentBackend[F[_]](
   }
 }
 
+private[gemini] object GeminiAgentBackend {
+  val DefaultMaxTokens: Int = 4096
+}
+
 object GeminiAgent {
 
   /** Entry point: `GeminiAgent.builder[F](client, model)`. The indirection lets `M` be inferred while `F` is given explicitly. */
@@ -170,7 +177,7 @@ object GeminiAgent {
         monad: sttp.monad.MonadError[F]
     ): AgentBuilder[F, M, String, String] =
       AgentBuilder[F, M](config =>
-        new GeminiAgentBackend[F](client, modelForIteration, config.userTools, config.systemPrompt, config.responseSchema)
+        new GeminiAgentBackend[F](client, modelForIteration, config.userTools, config.systemPrompt, config.responseSchema, config.maxTokens)
       )
 
     def apply(client: GeminiClient, modelName: String)(implicit

--- a/gemini/src/test/scala/sttp/ai/gemini/agent/GeminiAgentBackendSpec.scala
+++ b/gemini/src/test/scala/sttp/ai/gemini/agent/GeminiAgentBackendSpec.scala
@@ -43,10 +43,11 @@ class GeminiAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
   private def newBackend(
       tools: Seq[AgentTool[Identity, _]],
       systemPrompt: Option[String] = None,
-      responseSchema: Option[ResponseSchema[_]] = None
+      responseSchema: Option[ResponseSchema[_]] = None,
+      maxTokens: Option[Int] = None
   ): GeminiAgentBackend[Identity] = {
     val client = GeminiClient(GeminiConfig(apiKey = "test-key"))
-    new GeminiAgentBackend[Identity](client, _ => GeminiModel.CustomModel(testModel), tools, systemPrompt, responseSchema)(
+    new GeminiAgentBackend[Identity](client, _ => GeminiModel.CustomModel(testModel), tools, systemPrompt, responseSchema, maxTokens)(
       IdentityMonad
     )
   }
@@ -92,11 +93,12 @@ class GeminiAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
       includeTools: Boolean,
       history: ConversationHistory,
       systemPrompt: Option[String] = None,
-      responseSchema: Option[ResponseSchema[_]] = None
+      responseSchema: Option[ResponseSchema[_]] = None,
+      maxTokens: Option[Int] = None
   ): String = {
     val schema = parse(rawSchema).value.as[Schema](sttp.apispec.circe.schemaDecoder).value
     val tool = AgentTool.dynamic("create-event", "Creates an event", schema)(_ => "ok")
-    val backend = newBackend(Seq(tool), systemPrompt, responseSchema)
+    val backend = newBackend(Seq(tool), systemPrompt, responseSchema, maxTokens)
 
     val captured = new AtomicReference[GenericRequest[_, _]](null)
     val httpStub = DefaultSyncBackend.stub.whenAnyRequest.thenRespondF { request =>
@@ -119,6 +121,12 @@ class GeminiAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
   it should "bound the response with a default generation_config.max_output_tokens of 4096" in {
     val bodyJson = parse(captureRequestBody(includeTools = true, ConversationHistory.withInitialPrompt("hello"))).value
     bodyJson.hcursor.downField("generation_config").downField("max_output_tokens").as[Int] shouldBe Right(4096)
+  }
+
+  it should "send the configured max tokens as generation_config.max_output_tokens" in {
+    val bodyJson =
+      parse(captureRequestBody(includeTools = true, ConversationHistory.withInitialPrompt("hello"), maxTokens = Some(8192))).value
+    bodyJson.hcursor.downField("generation_config").downField("max_output_tokens").as[Int] shouldBe Right(8192)
   }
 
   it should "replay the full history as input steps" in {

--- a/openai/src/main/scala/sttp/ai/openai/agent/OpenAIAgent.scala
+++ b/openai/src/main/scala/sttp/ai/openai/agent/OpenAIAgent.scala
@@ -15,7 +15,8 @@ private[openai] class OpenAIAgentBackend[F[_]](
     val tools: Seq[AgentTool[F, _]],
     val systemPrompt: Option[String],
     responseSchema: Option[ResponseSchema[_]],
-    strictTools: Boolean
+    strictTools: Boolean,
+    maxTokens: Option[Int] = None
 )(implicit monad: sttp.monad.MonadError[F])
     extends AgentBackend[F] {
 
@@ -90,7 +91,9 @@ private[openai] class OpenAIAgentBackend[F[_]](
       model = modelForIteration(iterationInfo),
       messages = messages,
       tools = if (includeTools && convertedTools.nonEmpty) Some(convertedTools) else None,
-      responseFormat = responseFormat
+      responseFormat = responseFormat,
+      // maxCompletionTokens rather than the legacy maxTokens: reasoning models (GPT-5, o-series) reject max_tokens.
+      maxCompletionTokens = maxTokens
     )
     monad.flatMap(monad.map(openAI.createChatCompletion(request).send(backend))(_.body)) {
       case Right(response) =>
@@ -175,7 +178,15 @@ object OpenAIAgent {
         monad: sttp.monad.MonadError[F]
     ): AgentBuilder[F, M, String, String] =
       AgentBuilder[F, M](config =>
-        new OpenAIAgentBackend[F](openAI, modelForIteration, config.userTools, config.systemPrompt, config.responseSchema, strictTools)
+        new OpenAIAgentBackend[F](
+          openAI,
+          modelForIteration,
+          config.userTools,
+          config.systemPrompt,
+          config.responseSchema,
+          strictTools,
+          config.maxTokens
+        )
       )
 
     def apply(openAI: OpenAI, modelName: String)(implicit

--- a/openai/src/test/scala/sttp/ai/openai/agent/OpenAIAgentBackendSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/agent/OpenAIAgentBackendSpec.scala
@@ -29,14 +29,15 @@ class OpenAIAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
     AgentTool.dynamic("create", "Creates a thing", schema)(_ => "ok")
   }
 
-  private def backend(strictTools: Boolean): OpenAIAgentBackend[Identity] =
+  private def backend(strictTools: Boolean, maxTokens: Option[Int] = None): OpenAIAgentBackend[Identity] =
     new OpenAIAgentBackend[Identity](
       new OpenAI("test-key"),
       _ => ChatCompletionModel.GPT4oMini,
       Seq(testTool),
       None,
       None,
-      strictTools
+      strictTools,
+      maxTokens
     )(IdentityMonad)
 
   "OpenAIAgentBackend" should "register tools as strict with normalized schemas when strictTools is true" in {
@@ -57,13 +58,13 @@ class OpenAIAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
     params.hcursor.downField("properties").downField("note").downField("type").as[String] shouldBe Right("string")
   }
 
-  private def captureRequestBody(includeTools: Boolean): String = {
+  private def captureRequestBody(includeTools: Boolean, maxTokens: Option[Int] = None): String = {
     val captured = new AtomicReference[GenericRequest[_, _]](null)
     val httpStub = DefaultSyncBackend.stub.whenAnyRequest.thenRespondF { request =>
       captured.set(request)
       ResponseStub.adjust(sttp.ai.openai.fixtures.CompletionsFixture.structuredOutputsResponse, StatusCode.Ok)
     }
-    backend(strictTools = true).sendRequest(
+    backend(strictTools = true, maxTokens).sendRequest(
       ConversationHistory.withInitialPrompt("hello"),
       httpStub,
       includeTools = includeTools,
@@ -81,6 +82,15 @@ class OpenAIAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
 
   it should "omit tools from the request body when includeTools is false" in {
     captureRequestBody(includeTools = false) should not include "\"tools\""
+  }
+
+  it should "not send a completion-token cap by default" in {
+    captureRequestBody(includeTools = true) should not include "\"max_completion_tokens\""
+  }
+
+  it should "send the configured max tokens as max_completion_tokens" in {
+    val bodyJson = parse(captureRequestBody(includeTools = true, maxTokens = Some(8192))).value
+    bodyJson.hcursor.downField("max_completion_tokens").as[Int] shouldBe Right(8192)
   }
 
   it should "resolve the model per iteration via modelForIteration" in {


### PR DESCRIPTION
## Multi-turn conversations: conversation history in and out of the agent loop

Makes `sttp.ai.core.agent.Agent` usable as a chat: every run returns its full `ConversationHistory`, and a run can be seeded with a prior history plus a new user message — so the caller can load previous context, inspect the transcript, and keep talking:

```scala
val agent = ClaudeAgent.synchronous(ClaudeConfig.fromEnv, ClaudeModel.ClaudeHaiku4_5.value).build

val first  = agent.run("My name is Igor. What is 2+2?")(backend)
val second = agent.run("Multiply that by 10, and remind me of my name.", first.history)(backend)

second.history.entries // full transcript: seed + new user message + tool calls/results + final answer
```

A history can also be built or restored by hand (`ConversationHistory.empty.addUserPrompt(...).addAssistantResponse(...)`) and passed as the seed of a fresh run.

## How it works

- `AgentResult` gains `history: ConversationHistory` — the complete, replayable transcript of the run: the seed (if any), the rendered user message, assistant responses, tool calls with their results, and the final assistant answer (which the loop previously discarded). It is recorded on every exit path, including token-limit and forced-final ones.
- The history is kept valid as a seed for a follow-up run: per-request decorations (iteration markers, forced-finish instructions) are transient and not part of it, and tool calls from a forced final response are not recorded — they are never executed, and an unanswered `tool_use` would make the transcript unreplayable (Claude rejects such message sequences).
- `Agent` gains `run(in, history)` as the loop entry point; the existing `run(in)` is unchanged for callers and delegates with an empty history — behaviorally identical to before. `map`/`contramap` pass the history through; `andThen` stays stage-local: a seed history feeds only the first stage, and the combined result carries the last-run stage's history (documented in the scaladoc).
- Also adds `AgentBuilder.maxTokens(n)` — a per-LLM-call output-token cap, previously hard-coded. Maps to Claude `max_tokens` (default 4096, as before), Gemini `generation_config.max_output_tokens` (default 4096, as before), and OpenAI `max_completion_tokens` (unset by default, as before; the field reasoning models accept). Useful for chat-style loops where the 4096 default is easy to hit.

## Scope / compatibility

- Source-compatible for callers: `run(in)` keeps its signature, `AgentResult.history` and `AgentConfig.maxTokens` are appended defaulted fields, and no existing behavior changes when the new features are unused. The abstract method of `Agent` moved from `run(in)` to `run(in, history)`, which affects only direct third-party `Agent` implementors (custom integrations extend `AgentBackend`, which is unchanged).
- No new dependencies; cross-built on Scala 2.13 and 3 as before.
- Tests: 7 new cases in `AgentSpec` (transcript contents, forced-final tool-call exclusion, token-limit partial answer, seeded request shape, two-turn continuation, builder config) plus request-body assertions for `maxTokens` in all three provider backend specs. Full suite green.
- Docs: "Multi-turn conversations" section in `docs/agents/quickstart.md` and `maxTokens` in `docs/agents/configuration.md` (both mdoc-compiled).