### PR TITLE
Add support for Vector Store File Batches

### DIFF
--- a/openai/src/main/scala-2/sttp/ai/openai/json/OpenAIDerivedCodecs.scala
+++ b/openai/src/main/scala-2/sttp/ai/openai/json/OpenAIDerivedCodecs.scala
@@ -395,8 +395,6 @@ object OpenAIDerivedCodecs {
   implicit val deleteVectorStoreFileResponseCodec: Codec[VectorStoreFileResponseData.DeleteVectorStoreFileResponse] = deriveConfiguredCodec
   implicit val createVectorStoreFileBatchBodyEncoder: Encoder[VectorStoreFileBatchRequestBody.CreateVectorStoreFileBatchBody] =
     deriveConfiguredEncoder
-  implicit val listVectorStoreFilesInBatchBodyEncoder: Encoder[VectorStoreFileBatchRequestBody.ListVectorStoreFilesInBatchBody] =
-    deriveConfiguredEncoder
   implicit val vectorStoreFileBatchCodec: Codec[VectorStoreFileBatchResponseData.VectorStoreFileBatch] = deriveConfiguredCodec
 
   // threads request bodies

--- a/openai/src/main/scala-2/sttp/ai/openai/json/OpenAIDerivedCodecs.scala
+++ b/openai/src/main/scala-2/sttp/ai/openai/json/OpenAIDerivedCodecs.scala
@@ -74,6 +74,7 @@ import sttp.ai.openai.requests.admin.{
 }
 import sttp.ai.openai.requests.vectorstore.{VectorStoreRequestBody, VectorStoreResponseData}
 import sttp.ai.openai.requests.vectorstore.file.{FileStatus, VectorStoreFileRequestBody, VectorStoreFileResponseData}
+import sttp.ai.openai.requests.vectorstore.file.batch.{VectorStoreFileBatchRequestBody, VectorStoreFileBatchResponseData}
 import sttp.ai.openai.requests.threads.{ThreadsRequestBody, ThreadsResponseData}
 import sttp.ai.openai.requests.threads.messages.{ThreadMessagesRequestBody, ThreadMessagesResponseData => TMR}
 import sttp.ai.openai.requests.threads.runs.{ThreadRunsRequestBody, ThreadRunsResponseData => TRR}
@@ -392,6 +393,11 @@ object OpenAIDerivedCodecs {
   implicit val vectorStoreFileCodec: Codec[VectorStoreFileResponseData.VectorStoreFile] = deriveConfiguredCodec
   implicit val listVectorStoreFilesResponseCodec: Codec[VectorStoreFileResponseData.ListVectorStoreFilesResponse] = deriveConfiguredCodec
   implicit val deleteVectorStoreFileResponseCodec: Codec[VectorStoreFileResponseData.DeleteVectorStoreFileResponse] = deriveConfiguredCodec
+  implicit val createVectorStoreFileBatchBodyEncoder: Encoder[VectorStoreFileBatchRequestBody.CreateVectorStoreFileBatchBody] =
+    deriveConfiguredEncoder
+  implicit val listVectorStoreFilesInBatchBodyEncoder: Encoder[VectorStoreFileBatchRequestBody.ListVectorStoreFilesInBatchBody] =
+    deriveConfiguredEncoder
+  implicit val vectorStoreFileBatchCodec: Codec[VectorStoreFileBatchResponseData.VectorStoreFileBatch] = deriveConfiguredCodec
 
   // threads request bodies
   implicit val attachmentCodec: Codec[Attachment] = {

--- a/openai/src/main/scala-3/sttp/ai/openai/json/OpenAIDerivedCodecs.scala
+++ b/openai/src/main/scala-3/sttp/ai/openai/json/OpenAIDerivedCodecs.scala
@@ -71,6 +71,7 @@ import sttp.ai.openai.requests.admin.{
 }
 import sttp.ai.openai.requests.vectorstore.{VectorStoreRequestBody, VectorStoreResponseData}
 import sttp.ai.openai.requests.vectorstore.file.{FileStatus, VectorStoreFileRequestBody, VectorStoreFileResponseData}
+import sttp.ai.openai.requests.vectorstore.file.batch.{VectorStoreFileBatchRequestBody, VectorStoreFileBatchResponseData}
 import sttp.ai.openai.requests.threads.{ThreadsRequestBody, ThreadsResponseData}
 import sttp.ai.openai.requests.threads.messages.{ThreadMessagesRequestBody, ThreadMessagesResponseData => TMR}
 import sttp.ai.openai.requests.threads.runs.{ThreadRunsRequestBody, ThreadRunsResponseData => TRR}
@@ -375,6 +376,11 @@ object OpenAIDerivedCodecs {
   implicit val listVectorStoreFilesResponseCodec: Codec[VectorStoreFileResponseData.ListVectorStoreFilesResponse] = ConfiguredCodec.derived
   implicit val deleteVectorStoreFileResponseCodec: Codec[VectorStoreFileResponseData.DeleteVectorStoreFileResponse] =
     ConfiguredCodec.derived
+  implicit val createVectorStoreFileBatchBodyEncoder: Encoder[VectorStoreFileBatchRequestBody.CreateVectorStoreFileBatchBody] =
+    ConfiguredEncoder.derived
+  implicit val listVectorStoreFilesInBatchBodyEncoder: Encoder[VectorStoreFileBatchRequestBody.ListVectorStoreFilesInBatchBody] =
+    ConfiguredEncoder.derived
+  implicit val vectorStoreFileBatchCodec: Codec[VectorStoreFileBatchResponseData.VectorStoreFileBatch] = ConfiguredCodec.derived
 
   // threads request bodies
   implicit val attachmentCodec: Codec[Attachment] = {

--- a/openai/src/main/scala-3/sttp/ai/openai/json/OpenAIDerivedCodecs.scala
+++ b/openai/src/main/scala-3/sttp/ai/openai/json/OpenAIDerivedCodecs.scala
@@ -378,8 +378,6 @@ object OpenAIDerivedCodecs {
     ConfiguredCodec.derived
   implicit val createVectorStoreFileBatchBodyEncoder: Encoder[VectorStoreFileBatchRequestBody.CreateVectorStoreFileBatchBody] =
     ConfiguredEncoder.derived
-  implicit val listVectorStoreFilesInBatchBodyEncoder: Encoder[VectorStoreFileBatchRequestBody.ListVectorStoreFilesInBatchBody] =
-    ConfiguredEncoder.derived
   implicit val vectorStoreFileBatchCodec: Codec[VectorStoreFileBatchResponseData.VectorStoreFileBatch] = ConfiguredCodec.derived
 
   // threads request bodies

--- a/openai/src/main/scala/sttp/ai/openai/OpenAI.scala
+++ b/openai/src/main/scala/sttp/ai/openai/OpenAI.scala
@@ -55,6 +55,11 @@ import sttp.ai.openai.requests.vectorstore.file.VectorStoreFileResponseData.{
   ListVectorStoreFilesResponse,
   VectorStoreFile
 }
+import sttp.ai.openai.requests.vectorstore.file.batch.VectorStoreFileBatchRequestBody.{
+  CreateVectorStoreFileBatchBody,
+  ListVectorStoreFilesInBatchBody
+}
+import sttp.ai.openai.requests.vectorstore.file.batch.VectorStoreFileBatchResponseData.VectorStoreFileBatch
 import sttp.ai.openai.requests.{admin, batch, finetuning}
 
 import java.io.{File, InputStream}
@@ -1577,6 +1582,80 @@ class OpenAI(
       .delete(openAIUris.vectorStoreFile(vectorStoreId, fileId))
       .response(asJson_parseErrors[DeleteVectorStoreFileResponse])
 
+  /** Create a vector store file batch.
+    *
+    * [[https://platform.openai.com/docs/api-reference/vector-stores-file-batches/createBatch]]
+    *
+    * @param vectorStoreId
+    *   The ID of the vector store for which to create a file batch.
+    * @param createVectorStoreFileBatchBody
+    *   Properties of the batch (file ids to attach).
+    * @return
+    *   A vector store file batch object.
+    */
+  def createVectorStoreFileBatch(
+      vectorStoreId: String,
+      createVectorStoreFileBatchBody: CreateVectorStoreFileBatchBody
+  ): Request[Either[OpenAIException, VectorStoreFileBatch]] =
+    betaOpenAIAuthRequest
+      .post(openAIUris.vectorStoreFileBatches(vectorStoreId))
+      .body(asJson(createVectorStoreFileBatchBody))
+      .response(asJson_parseErrors[VectorStoreFileBatch])
+
+  /** Retrieves a vector store file batch.
+    *
+    * [[https://platform.openai.com/docs/api-reference/vector-stores-file-batches/getBatch]]
+    *
+    * @param vectorStoreId
+    *   The ID of the vector store that the file batch belongs to.
+    * @param batchId
+    *   The ID of the file batch being retrieved.
+    * @return
+    *   The vector store file batch object.
+    */
+  def retrieveVectorStoreFileBatch(vectorStoreId: String, batchId: String): Request[Either[OpenAIException, VectorStoreFileBatch]] =
+    betaOpenAIAuthRequest
+      .get(openAIUris.vectorStoreFileBatch(vectorStoreId, batchId))
+      .response(asJson_parseErrors[VectorStoreFileBatch])
+
+  /** Cancel a vector store file batch. This attempts to cancel the processing of files in this batch as soon as possible.
+    *
+    * [[https://platform.openai.com/docs/api-reference/vector-stores-file-batches/cancelBatch]]
+    *
+    * @param vectorStoreId
+    *   The ID of the vector store that the file batch belongs to.
+    * @param batchId
+    *   The ID of the file batch to cancel.
+    * @return
+    *   The modified vector store file batch object.
+    */
+  def cancelVectorStoreFileBatch(vectorStoreId: String, batchId: String): Request[Either[OpenAIException, VectorStoreFileBatch]] =
+    betaOpenAIAuthRequest
+      .post(openAIUris.vectorStoreFileBatchCancel(vectorStoreId, batchId))
+      .response(asJson_parseErrors[VectorStoreFileBatch])
+
+  /** Returns a list of vector store files in a batch.
+    *
+    * [[https://platform.openai.com/docs/api-reference/vector-stores-file-batches/listBatchFiles]]
+    *
+    * @param vectorStoreId
+    *   The ID of the vector store that the files belong to.
+    * @param batchId
+    *   The ID of the file batch that the files belong to.
+    * @param queryParameters
+    *   Search params
+    * @return
+    *   A list of vector store file objects.
+    */
+  def listVectorStoreFilesInBatch(
+      vectorStoreId: String,
+      batchId: String,
+      queryParameters: ListVectorStoreFilesInBatchBody = ListVectorStoreFilesInBatchBody()
+  ): Request[Either[OpenAIException, ListVectorStoreFilesResponse]] =
+    betaOpenAIAuthRequest
+      .get(openAIUris.vectorStoreFileBatchFiles(vectorStoreId, batchId).withParams(queryParameters.toMap))
+      .response(asJson_parseErrors[ListVectorStoreFilesResponse])
+
   /** Creates and executes a batch from an uploaded file of requests
     *
     * [[https://platform.openai.com/docs/api-reference/batch/create]]
@@ -1801,6 +1880,14 @@ private class OpenAIUris(val baseUri: Uri) {
     vectorStore(vectorStoreId).addPath("files")
   def vectorStoreFile(vectorStoreId: String, fileId: String): Uri =
     vectorStoreFiles(vectorStoreId).addPath(fileId)
+  def vectorStoreFileBatches(vectorStoreId: String): Uri =
+    vectorStore(vectorStoreId).addPath("file_batches")
+  def vectorStoreFileBatch(vectorStoreId: String, batchId: String): Uri =
+    vectorStoreFileBatches(vectorStoreId).addPath(batchId)
+  def vectorStoreFileBatchCancel(vectorStoreId: String, batchId: String): Uri =
+    vectorStoreFileBatch(vectorStoreId, batchId).addPath("cancel")
+  def vectorStoreFileBatchFiles(vectorStoreId: String, batchId: String): Uri =
+    vectorStoreFileBatch(vectorStoreId, batchId).addPath("files")
 }
 
 object OpenAIUris {

--- a/openai/src/main/scala/sttp/ai/openai/OpenAI.scala
+++ b/openai/src/main/scala/sttp/ai/openai/OpenAI.scala
@@ -55,10 +55,7 @@ import sttp.ai.openai.requests.vectorstore.file.VectorStoreFileResponseData.{
   ListVectorStoreFilesResponse,
   VectorStoreFile
 }
-import sttp.ai.openai.requests.vectorstore.file.batch.VectorStoreFileBatchRequestBody.{
-  CreateVectorStoreFileBatchBody,
-  ListVectorStoreFilesInBatchBody
-}
+import sttp.ai.openai.requests.vectorstore.file.batch.VectorStoreFileBatchRequestBody.CreateVectorStoreFileBatchBody
 import sttp.ai.openai.requests.vectorstore.file.batch.VectorStoreFileBatchResponseData.VectorStoreFileBatch
 import sttp.ai.openai.requests.{admin, batch, finetuning}
 
@@ -1650,7 +1647,7 @@ class OpenAI(
   def listVectorStoreFilesInBatch(
       vectorStoreId: String,
       batchId: String,
-      queryParameters: ListVectorStoreFilesInBatchBody = ListVectorStoreFilesInBatchBody()
+      queryParameters: ListVectorStoreFilesBody = ListVectorStoreFilesBody()
   ): Request[Either[OpenAIException, ListVectorStoreFilesResponse]] =
     betaOpenAIAuthRequest
       .get(openAIUris.vectorStoreFileBatchFiles(vectorStoreId, batchId).withParams(queryParameters.toMap))

--- a/openai/src/main/scala/sttp/ai/openai/OpenAISyncClient.scala
+++ b/openai/src/main/scala/sttp/ai/openai/OpenAISyncClient.scala
@@ -55,6 +55,11 @@ import sttp.ai.openai.requests.vectorstore.file.VectorStoreFileResponseData.{
   ListVectorStoreFilesResponse,
   VectorStoreFile
 }
+import sttp.ai.openai.requests.vectorstore.file.batch.VectorStoreFileBatchRequestBody.{
+  CreateVectorStoreFileBatchBody,
+  ListVectorStoreFilesInBatchBody
+}
+import sttp.ai.openai.requests.vectorstore.file.batch.VectorStoreFileBatchResponseData.VectorStoreFileBatch
 import sttp.ai.openai.requests.{admin, batch, finetuning}
 import io.circe.{parser, Decoder}
 import sttp.tapir.{Schema => TapirSchema}
@@ -1123,6 +1128,63 @@ class OpenAISyncClient private (
     */
   def deleteVectorStoreFile(vectorStoreId: String, fileId: String): DeleteVectorStoreFileResponse =
     sendOrThrow(openAI.deleteVectorStoreFile(vectorStoreId, fileId))
+
+  /** Creates vector store file batch
+    *
+    * @param vectorStoreId
+    *   Id of vector store
+    * @param createVectorStoreFileBatchBody
+    *   Properties of the batch (file ids to attach)
+    * @return
+    *   Newly created vector store file batch
+    */
+  def createVectorStoreFileBatch(
+      vectorStoreId: String,
+      createVectorStoreFileBatchBody: CreateVectorStoreFileBatchBody
+  ): VectorStoreFileBatch =
+    sendOrThrow(openAI.createVectorStoreFileBatch(vectorStoreId, createVectorStoreFileBatchBody))
+
+  /** Retrieves vector store file batch by id
+    *
+    * @param vectorStoreId
+    *   Id of vector store
+    * @param batchId
+    *   Id of vector store file batch
+    * @return
+    *   Vector store file batch
+    */
+  def retrieveVectorStoreFileBatch(vectorStoreId: String, batchId: String): VectorStoreFileBatch =
+    sendOrThrow(openAI.retrieveVectorStoreFileBatch(vectorStoreId, batchId))
+
+  /** Cancels vector store file batch by id
+    *
+    * @param vectorStoreId
+    *   Id of vector store
+    * @param batchId
+    *   Id of vector store file batch
+    * @return
+    *   Modified vector store file batch
+    */
+  def cancelVectorStoreFileBatch(vectorStoreId: String, batchId: String): VectorStoreFileBatch =
+    sendOrThrow(openAI.cancelVectorStoreFileBatch(vectorStoreId, batchId))
+
+  /** List files belonging to particular vector store file batch
+    *
+    * @param vectorStoreId
+    *   Id of vector store
+    * @param batchId
+    *   Id of vector store file batch
+    * @param queryParameters
+    *   Search params
+    * @return
+    *   List of vector store files
+    */
+  def listVectorStoreFilesInBatch(
+      vectorStoreId: String,
+      batchId: String,
+      queryParameters: ListVectorStoreFilesInBatchBody = ListVectorStoreFilesInBatchBody()
+  ): ListVectorStoreFilesResponse =
+    sendOrThrow(openAI.listVectorStoreFilesInBatch(vectorStoreId, batchId, queryParameters))
 
   /** Creates and executes a batch from an uploaded file of requests
     *

--- a/openai/src/main/scala/sttp/ai/openai/OpenAISyncClient.scala
+++ b/openai/src/main/scala/sttp/ai/openai/OpenAISyncClient.scala
@@ -55,10 +55,7 @@ import sttp.ai.openai.requests.vectorstore.file.VectorStoreFileResponseData.{
   ListVectorStoreFilesResponse,
   VectorStoreFile
 }
-import sttp.ai.openai.requests.vectorstore.file.batch.VectorStoreFileBatchRequestBody.{
-  CreateVectorStoreFileBatchBody,
-  ListVectorStoreFilesInBatchBody
-}
+import sttp.ai.openai.requests.vectorstore.file.batch.VectorStoreFileBatchRequestBody.CreateVectorStoreFileBatchBody
 import sttp.ai.openai.requests.vectorstore.file.batch.VectorStoreFileBatchResponseData.VectorStoreFileBatch
 import sttp.ai.openai.requests.{admin, batch, finetuning}
 import io.circe.{parser, Decoder}
@@ -1182,7 +1179,7 @@ class OpenAISyncClient private (
   def listVectorStoreFilesInBatch(
       vectorStoreId: String,
       batchId: String,
-      queryParameters: ListVectorStoreFilesInBatchBody = ListVectorStoreFilesInBatchBody()
+      queryParameters: ListVectorStoreFilesBody = ListVectorStoreFilesBody()
   ): ListVectorStoreFilesResponse =
     sendOrThrow(openAI.listVectorStoreFilesInBatch(vectorStoreId, batchId, queryParameters))
 

--- a/openai/src/main/scala/sttp/ai/openai/requests/admin/AdminApiKeyResponse.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/admin/AdminApiKeyResponse.scala
@@ -23,8 +23,8 @@ case class ListAdminApiKeyResponse(
     `object`: String = "list",
     data: Seq[AdminApiKeyResponse],
     hasMore: Boolean,
-    firstId: String,
-    lastId: String
+    firstId: Option[String],
+    lastId: Option[String]
 )
 
 case class DeleteAdminApiKeyResponse(

--- a/openai/src/main/scala/sttp/ai/openai/requests/assistants/AssistantsResponseData.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/assistants/AssistantsResponseData.scala
@@ -68,8 +68,8 @@ object AssistantsResponseData {
   case class ListAssistantsResponse(
       `object`: String = "list",
       data: Seq[AssistantData],
-      firstId: String,
-      lastId: String,
+      firstId: Option[String],
+      lastId: Option[String],
       hasMore: Boolean
   )
 

--- a/openai/src/main/scala/sttp/ai/openai/requests/batch/BatchResponse.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/batch/BatchResponse.scala
@@ -103,7 +103,7 @@ case class RequestCounts(
 case class ListBatchResponse(
     `object`: String = "list",
     data: Seq[BatchResponse],
-    firstId: String,
-    lastId: String,
+    firstId: Option[String],
+    lastId: Option[String],
     hasMore: Boolean
 )

--- a/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/ChatRequestResponseData.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/ChatRequestResponseData.scala
@@ -47,8 +47,8 @@ object ChatRequestResponseData {
   case class ListMessageResponse(
       `object`: String = "list",
       data: Seq[Message],
-      firstId: String,
-      lastId: String,
+      firstId: Option[String],
+      lastId: Option[String],
       hasMore: Boolean
   )
 
@@ -165,8 +165,8 @@ object ChatRequestResponseData {
   case class ListChatResponse(
       `object`: String = "list",
       data: Seq[ChatResponse],
-      firstId: String,
-      lastId: String,
+      firstId: Option[String],
+      lastId: Option[String],
       hasMore: Boolean
   )
 

--- a/openai/src/main/scala/sttp/ai/openai/requests/finetuning/FineTuningJobResponse.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/finetuning/FineTuningJobResponse.scala
@@ -166,8 +166,8 @@ case class FineTuningJobCheckpointResponse(
 case class ListFineTuningJobCheckpointResponse(
     `object`: String = "list",
     data: Seq[FineTuningJobCheckpointResponse],
-    firstId: String,
-    lastId: String,
+    firstId: Option[String],
+    lastId: Option[String],
     hasMore: Boolean
 )
 

--- a/openai/src/main/scala/sttp/ai/openai/requests/responses/InputItemsListResponseBody.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/responses/InputItemsListResponseBody.scala
@@ -20,9 +20,9 @@ import sttp.tapir.{Schema => TSchema}
   */
 case class InputItemsListResponseBody(
     data: List[InputItemsListResponseBody.InputItem],
-    firstId: String,
+    firstId: Option[String],
     hasMore: Boolean,
-    lastId: String,
+    lastId: Option[String],
     `object`: String
 )
 

--- a/openai/src/main/scala/sttp/ai/openai/requests/threads/messages/ThreadMessagesResponseData.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/threads/messages/ThreadMessagesResponseData.scala
@@ -53,8 +53,8 @@ object ThreadMessagesResponseData {
   case class ListMessagesResponse(
       `object`: String = "list",
       data: Seq[MessageData],
-      firstId: String,
-      lastId: String,
+      firstId: Option[String],
+      lastId: Option[String],
       hasMore: Boolean
   )
 

--- a/openai/src/main/scala/sttp/ai/openai/requests/threads/runs/ThreadRunsResponseData.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/threads/runs/ThreadRunsResponseData.scala
@@ -157,8 +157,8 @@ object ThreadRunsResponseData {
   case class ListRunsResponse(
       `object`: String = "list",
       data: Seq[RunData],
-      firstId: String,
-      lastId: String,
+      firstId: Option[String],
+      lastId: Option[String],
       hasMore: Boolean
   )
 
@@ -387,8 +387,8 @@ object ThreadRunsResponseData {
   case class ListRunStepsResponse(
       `object`: String = "list",
       data: Seq[RunStepData],
-      firstId: String,
-      lastId: String,
+      firstId: Option[String],
+      lastId: Option[String],
       hasMore: Boolean
   )
 

--- a/openai/src/main/scala/sttp/ai/openai/requests/vectorstore/VectorStoreResponseData.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/vectorstore/VectorStoreResponseData.scala
@@ -69,17 +69,17 @@ object VectorStoreResponseData {
     * @param data
     *   A list of vector store objects.
     * @param firstId
-    *   Id of first object
+    *   Id of first object, or None when the list is empty
     * @param lastId
-    *   Id of last object
+    *   Id of last object, or None when the list is empty
     * @param hasMore
     *   Denotes if there are more object available
     */
   case class ListVectorStoresResponse(
       `object`: String = "list",
       data: Seq[VectorStore],
-      firstId: String,
-      lastId: String,
+      firstId: Option[String],
+      lastId: Option[String],
       hasMore: Boolean
   )
 

--- a/openai/src/main/scala/sttp/ai/openai/requests/vectorstore/file/FileStatus.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/vectorstore/file/FileStatus.scala
@@ -5,3 +5,14 @@ case object InProgress extends FileStatus
 case object Completed extends FileStatus
 case object Failed extends FileStatus
 case object Cancelled extends FileStatus
+
+object FileStatus {
+
+  /** The snake_case value used by the API (e.g. as the `filter` query parameter). */
+  def toApiValue(status: FileStatus): String = status match {
+    case InProgress => "in_progress"
+    case Completed  => "completed"
+    case Failed     => "failed"
+    case Cancelled  => "cancelled"
+  }
+}

--- a/openai/src/main/scala/sttp/ai/openai/requests/vectorstore/file/VectorStoreFileResponseData.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/vectorstore/file/VectorStoreFileResponseData.scala
@@ -51,17 +51,17 @@ object VectorStoreFileResponseData {
     * @param data
     *   A list of vector store file objects.
     * @param firstId
-    *   Id of first object
+    *   Id of first object, or None when the list is empty
     * @param lastId
-    *   Id of last object
+    *   Id of last object, or None when the list is empty
     * @param hasMore
     *   Denotes if there are more object available
     */
   case class ListVectorStoreFilesResponse(
       `object`: String = "list",
       data: Seq[VectorStoreFile],
-      firstId: String,
-      lastId: String,
+      firstId: Option[String],
+      lastId: Option[String],
       hasMore: Boolean
   )
 

--- a/openai/src/main/scala/sttp/ai/openai/requests/vectorstore/file/batch/VectorStoreFileBatchRequestBody.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/vectorstore/file/batch/VectorStoreFileBatchRequestBody.scala
@@ -1,17 +1,19 @@
-package sttp.ai.openai.requests.vectorstore.file
+package sttp.ai.openai.requests.vectorstore.file.batch
 
-object VectorStoreFileRequestBody {
+import sttp.ai.openai.requests.vectorstore.file.FileStatus
 
-  /** Create a vector store file by attaching a File to a vector store.
+object VectorStoreFileBatchRequestBody {
+
+  /** Create a vector store file batch by attaching multiple Files to a vector store.
     *
-    * @param fileId
-    *   A File ID that the vector store should use. Useful for tools like file_search that can access files.
+    * @param fileIds
+    *   A list of File IDs that the vector store should use. Useful for tools like file_search that can access files.
     */
-  case class CreateVectorStoreFileBody(
-      fileId: String
+  case class CreateVectorStoreFileBatchBody(
+      fileIds: Seq[String]
   )
 
-  /** Represents options for listing objects with pagination and filtering.
+  /** Represents options for listing files in a vector store file batch with pagination and filtering.
     *
     * @param limit
     *   Defaults to 20 A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 20.
@@ -28,7 +30,7 @@ object VectorStoreFileRequestBody {
     * @param filter
     *   Optional. Filter by file status. Possible values are "in_progress", "completed", "failed", "cancelled".
     */
-  case class ListVectorStoreFilesBody(
+  case class ListVectorStoreFilesInBatchBody(
       limit: Int = 20,
       order: String = "desc",
       after: Option[String] = None,

--- a/openai/src/main/scala/sttp/ai/openai/requests/vectorstore/file/batch/VectorStoreFileBatchRequestBody.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/vectorstore/file/batch/VectorStoreFileBatchRequestBody.scala
@@ -1,7 +1,5 @@
 package sttp.ai.openai.requests.vectorstore.file.batch
 
-import sttp.ai.openai.requests.vectorstore.file.FileStatus
-
 object VectorStoreFileBatchRequestBody {
 
   /** Create a vector store file batch by attaching multiple Files to a vector store.
@@ -12,38 +10,5 @@ object VectorStoreFileBatchRequestBody {
   case class CreateVectorStoreFileBatchBody(
       fileIds: Seq[String]
   )
-
-  /** Represents options for listing files in a vector store file batch with pagination and filtering.
-    *
-    * @param limit
-    *   Defaults to 20 A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 20.
-    * @param order
-    *   Defaults to desc Sort order by the created_at timestamp of the objects. asc for ascending order and desc for descending order.
-    * @param after
-    *   A cursor for use in pagination. after is an object ID that defines your place in the list. For instance, if you make a list request
-    *   and receive 100 objects, ending with obj_foo, your subsequent call can include after=obj_foo in order to fetch the next page of the
-    *   list.
-    * @param before
-    *   A cursor for use in pagination. before is an object ID that defines your place in the list. For instance, if you make a list request
-    *   and receive 100 objects, ending with obj_foo, your subsequent call can include before=obj_foo in order to fetch the previous page of
-    *   the list.
-    * @param filter
-    *   Optional. Filter by file status. Possible values are "in_progress", "completed", "failed", "cancelled".
-    */
-  case class ListVectorStoreFilesInBatchBody(
-      limit: Int = 20,
-      order: String = "desc",
-      after: Option[String] = None,
-      before: Option[String] = None,
-      filter: Option[FileStatus] = None
-  ) {
-    def toMap: Map[String, String] = {
-      val map = Map("limit" -> limit.toString, "order" -> order)
-      map ++
-        after.map("after" -> _) ++
-        before.map("before" -> _) ++
-        filter.map(f => "filter" -> FileStatus.toApiValue(f))
-    }
-  }
 
 }

--- a/openai/src/main/scala/sttp/ai/openai/requests/vectorstore/file/batch/VectorStoreFileBatchResponseData.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/vectorstore/file/batch/VectorStoreFileBatchResponseData.scala
@@ -1,0 +1,32 @@
+package sttp.ai.openai.requests.vectorstore.file.batch
+
+import sttp.ai.openai.requests.vectorstore.VectorStoreResponseData.FileCounts
+import sttp.ai.openai.requests.vectorstore.file.FileStatus
+
+object VectorStoreFileBatchResponseData {
+
+  /** Represents a batch of files attached to a vector store.
+    *
+    * @param id
+    *   The identifier, which can be referenced in API endpoints.
+    * @param object
+    *   The object type, which is always vector_store.file_batch.
+    * @param createdAt
+    *   The Unix timestamp (in seconds) for when the vector store files batch was created.
+    * @param vectorStoreId
+    *   The ID of the vector store that the Files are attached to.
+    * @param status
+    *   The status of the vector store files batch. Possible values are "in_progress", "completed", "cancelled", or "failed".
+    * @param fileCounts
+    *   Number of files in the batch in each status.
+    */
+  case class VectorStoreFileBatch(
+      id: String,
+      `object`: String,
+      createdAt: Int,
+      vectorStoreId: String,
+      status: FileStatus,
+      fileCounts: FileCounts
+  )
+
+}

--- a/openai/src/main/scala/sttp/ai/openai/requests/vectorstore/file/batch/VectorStoreFileBatchResponseData.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/vectorstore/file/batch/VectorStoreFileBatchResponseData.scala
@@ -10,7 +10,8 @@ object VectorStoreFileBatchResponseData {
     * @param id
     *   The identifier, which can be referenced in API endpoints.
     * @param object
-    *   The object type, which is always vector_store.file_batch.
+    *   The object type. The live API returns vector_store.file_batch (observed 2026-08), while the OpenAPI spec's enum lists
+    *   vector_store.files_batch; treat this as an opaque string.
     * @param createdAt
     *   The Unix timestamp (in seconds) for when the vector store files batch was created.
     * @param vectorStoreId

--- a/openai/src/test/scala/sttp/ai/openai/openai/OpenAIUrisSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/OpenAIUrisSpec.scala
@@ -34,4 +34,18 @@ class OpenAIUrisSpec extends AnyFlatSpec with Matchers {
     uris.Models.toString shouldBe "https://api.openai.com/v1/models": Unit
     uris.Transcriptions.toString shouldBe "https://api.openai.com/v1/audio/transcriptions"
   }
+
+  "OpenAIUris vector store paths" should "match the OpenAI API reference" in {
+    val uris = new OpenAIUris(plainBase)
+    val base = "https://api.openai.com/v1/vector_stores"
+
+    uris.VectorStores.toString shouldBe base: Unit
+    uris.vectorStore("vs_1").toString shouldBe s"$base/vs_1": Unit
+    uris.vectorStoreFiles("vs_1").toString shouldBe s"$base/vs_1/files": Unit
+    uris.vectorStoreFile("vs_1", "file_1").toString shouldBe s"$base/vs_1/files/file_1": Unit
+    uris.vectorStoreFileBatches("vs_1").toString shouldBe s"$base/vs_1/file_batches": Unit
+    uris.vectorStoreFileBatch("vs_1", "vsfb_1").toString shouldBe s"$base/vs_1/file_batches/vsfb_1": Unit
+    uris.vectorStoreFileBatchCancel("vs_1", "vsfb_1").toString shouldBe s"$base/vs_1/file_batches/vsfb_1/cancel": Unit
+    uris.vectorStoreFileBatchFiles("vs_1", "vsfb_1").toString shouldBe s"$base/vs_1/file_batches/vsfb_1/files"
+  }
 }

--- a/openai/src/test/scala/sttp/ai/openai/openai/fixtures/VectorStoreFileBatchFixture.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/fixtures/VectorStoreFileBatchFixture.scala
@@ -1,0 +1,51 @@
+package sttp.ai.openai.fixtures
+
+object VectorStoreFileBatchFixture {
+
+  val jsonCreateRequest: String =
+    """{
+      |  "file_ids": ["file_1", "file_2"]
+      |}""".stripMargin
+
+  val jsonListRequest: String =
+    """{
+      |  "limit": 30,
+      |  "order": "asc",
+      |  "after": "111",
+      |  "before": "222",
+      |  "filter": "in_progress"
+      |}""".stripMargin
+
+  val jsonObjectInProgress: String =
+    """{
+      |  "id": "vsfb_1",
+      |  "object": "vector_store.file_batch",
+      |  "created_at": 1698107661,
+      |  "vector_store_id": "vs_1",
+      |  "status": "in_progress",
+      |  "file_counts": {
+      |    "in_progress": 2,
+      |    "completed": 0,
+      |    "failed": 0,
+      |    "cancelled": 0,
+      |    "total": 2
+      |  }
+      |}""".stripMargin
+
+  val jsonObjectCompleted: String =
+    """{
+      |  "id": "vsfb_1",
+      |  "object": "vector_store.file_batch",
+      |  "created_at": 1698107661,
+      |  "vector_store_id": "vs_1",
+      |  "status": "completed",
+      |  "file_counts": {
+      |    "in_progress": 0,
+      |    "completed": 1,
+      |    "failed": 1,
+      |    "cancelled": 0,
+      |    "total": 2
+      |  }
+      |}""".stripMargin
+
+}

--- a/openai/src/test/scala/sttp/ai/openai/openai/fixtures/VectorStoreFileBatchFixture.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/fixtures/VectorStoreFileBatchFixture.scala
@@ -7,15 +7,6 @@ object VectorStoreFileBatchFixture {
       |  "file_ids": ["file_1", "file_2"]
       |}""".stripMargin
 
-  val jsonListRequest: String =
-    """{
-      |  "limit": 30,
-      |  "order": "asc",
-      |  "after": "111",
-      |  "before": "222",
-      |  "filter": "in_progress"
-      |}""".stripMargin
-
   val jsonObjectInProgress: String =
     """{
       |  "id": "vsfb_1",

--- a/openai/src/test/scala/sttp/ai/openai/openai/fixtures/VectorStoreFileFixture.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/fixtures/VectorStoreFileFixture.scala
@@ -77,4 +77,13 @@ object VectorStoreFileFixture {
       | "object": "vector_store.file.deleted",
       | "deleted": true
       |}""".stripMargin
+  val jsonEmptyList: String =
+    """{
+      |  "object": "list",
+      |  "data": [],
+      |  "first_id": null,
+      |  "last_id": null,
+      |  "has_more": false
+      |}""".stripMargin
+
 }

--- a/openai/src/test/scala/sttp/ai/openai/openai/fixtures/VectorStoreFixture.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/fixtures/VectorStoreFixture.scala
@@ -94,4 +94,13 @@ object VectorStoreFixture {
       | "object": "vector_store.deleted",
       | "deleted": true
       |}""".stripMargin
+  val jsonEmptyList: String =
+    """{
+      |  "object": "list",
+      |  "data": [],
+      |  "first_id": null,
+      |  "last_id": null,
+      |  "has_more": false
+      |}""".stripMargin
+
 }

--- a/openai/src/test/scala/sttp/ai/openai/openai/requests/BatchDataSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/requests/BatchDataSpec.scala
@@ -44,8 +44,8 @@ class BatchDataSpec extends AnyFlatSpec with Matchers with EitherValues {
     val expectedResponse: ListBatchResponse = ListBatchResponse(
       data = Seq(BatchFixture.batchResponse),
       hasMore = true,
-      firstId = "ftckpt_zc4Q7MP6XxulcVzj4MZdwsAB",
-      lastId = "ftckpt_enQCFmOTGj3syEpYVhBRLTSy"
+      firstId = Some("ftckpt_zc4Q7MP6XxulcVzj4MZdwsAB"),
+      lastId = Some("ftckpt_enQCFmOTGj3syEpYVhBRLTSy")
     )
     // when
     val deserializedJsonResponse: Either[Exception, ListBatchResponse] =

--- a/openai/src/test/scala/sttp/ai/openai/openai/requests/admin/AdminApiKeyDataSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/requests/admin/AdminApiKeyDataSpec.scala
@@ -39,8 +39,8 @@ class AdminApiKeyDataSpec extends AnyFlatSpec with Matchers with EitherValues {
     val expectedResponse: ListAdminApiKeyResponse = ListAdminApiKeyResponse(
       data = Seq(AdminFixture.adminApiKeyResponse),
       hasMore = false,
-      firstId = "key_abc",
-      lastId = "key_abc"
+      firstId = Some("key_abc"),
+      lastId = Some("key_abc")
     )
     // when
     val deserializedJsonResponse: Either[Exception, ListAdminApiKeyResponse] =

--- a/openai/src/test/scala/sttp/ai/openai/openai/requests/assistants/AssistantsDataSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/requests/assistants/AssistantsDataSpec.scala
@@ -110,8 +110,8 @@ class AssistantsDataSpec extends AnyFlatSpec with Matchers with EitherValues {
           metadata = Map.empty
         )
       ),
-      firstId = "asst_abc123",
-      lastId = "asst_abc789",
+      firstId = Some("asst_abc123"),
+      lastId = Some("asst_abc789"),
       hasMore = false
     )
 
@@ -169,8 +169,8 @@ class AssistantsDataSpec extends AnyFlatSpec with Matchers with EitherValues {
           metadata = Map.empty
         )
       ),
-      firstId = "asst_abc123",
-      lastId = "asst_abc789",
+      firstId = Some("asst_abc123"),
+      lastId = Some("asst_abc789"),
       hasMore = false
     )
 

--- a/openai/src/test/scala/sttp/ai/openai/openai/requests/completions/chat/ChatDataSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/requests/completions/chat/ChatDataSpec.scala
@@ -42,8 +42,8 @@ class ChatDataSpec extends AnyFlatSpec with Matchers with EitherValues {
     val jsonResponse = fixtures.ChatFixture.jsonListChatResponse
     val expectedResponse = ListChatResponse(
       data = Seq(),
-      firstId = "chatcmpl-AyPNinnUqUDYo9SAdA52NobMflmj2",
-      lastId = "chatcmpl-AyPNinnUqUDYo9SAdA52NobMflmj2",
+      firstId = Some("chatcmpl-AyPNinnUqUDYo9SAdA52NobMflmj2"),
+      lastId = Some("chatcmpl-AyPNinnUqUDYo9SAdA52NobMflmj2"),
       hasMore = false
     )
     // when
@@ -73,8 +73,8 @@ class ChatDataSpec extends AnyFlatSpec with Matchers with EitherValues {
           )
         )
       ),
-      firstId = "chatcmpl-76FxnKOjnPkDVYTAQ1wK8iUNFJPvR",
-      lastId = "chatcmpl-76FxnKOjnPkDVYTAQ1wK8iUNFJPvR",
+      firstId = Some("chatcmpl-76FxnKOjnPkDVYTAQ1wK8iUNFJPvR"),
+      lastId = Some("chatcmpl-76FxnKOjnPkDVYTAQ1wK8iUNFJPvR"),
       hasMore = true
     )
     // when

--- a/openai/src/test/scala/sttp/ai/openai/openai/requests/finetuning/FineTuningDataSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/requests/finetuning/FineTuningDataSpec.scala
@@ -161,8 +161,8 @@ class FineTuningDataSpec extends AnyFlatSpec with Matchers with EitherValues {
             stepNumber = 2000
           )
         ),
-      firstId = "ftckpt_zc4Q7MP6XxulcVzj4MZdwsAB",
-      lastId = "ftckpt_enQCFmOTGj3syEpYVhBRLTSy",
+      firstId = Some("ftckpt_zc4Q7MP6XxulcVzj4MZdwsAB"),
+      lastId = Some("ftckpt_enQCFmOTGj3syEpYVhBRLTSy"),
       hasMore = true
     )
     // when

--- a/openai/src/test/scala/sttp/ai/openai/openai/requests/responses/InputItemsListDataSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/requests/responses/InputItemsListDataSpec.scala
@@ -40,8 +40,8 @@ class InputItemsListDataSpec extends AnyFlatSpec with Matchers with EitherValues
 
     // then
     deserializedResponse.`object` shouldBe "list"
-    deserializedResponse.firstId shouldBe "msg_abc123"
-    deserializedResponse.lastId shouldBe "msg_abc123"
+    deserializedResponse.firstId shouldBe Some("msg_abc123")
+    deserializedResponse.lastId shouldBe Some("msg_abc123")
     deserializedResponse.hasMore shouldBe false
     deserializedResponse.data should have size 1
 

--- a/openai/src/test/scala/sttp/ai/openai/openai/requests/threads/messages/ThreadMessagesDataSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/requests/threads/messages/ThreadMessagesDataSpec.scala
@@ -109,8 +109,8 @@ class ThreadMessagesDataSpec extends AnyFlatSpec with Matchers with EitherValues
           metadata = Map.empty
         )
       ),
-      firstId = "msg_abc123",
-      lastId = "msg_abc456",
+      firstId = Some("msg_abc123"),
+      lastId = Some("msg_abc456"),
       hasMore = false
     )
 

--- a/openai/src/test/scala/sttp/ai/openai/openai/requests/threads/runs/ThreadRunsDataSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/requests/threads/runs/ThreadRunsDataSpec.scala
@@ -183,8 +183,8 @@ class ThreadRunsDataSpec extends AnyFlatSpec with Matchers with EitherValues {
             )
           )
         ),
-        firstId = "run_abc123",
-        lastId = "run_abc456",
+        firstId = Some("run_abc123"),
+        lastId = Some("run_abc456"),
         hasMore = false
       )
 
@@ -230,8 +230,8 @@ class ThreadRunsDataSpec extends AnyFlatSpec with Matchers with EitherValues {
             )
           )
         ),
-        firstId = "step_abc123",
-        lastId = "step_abc456",
+        firstId = Some("step_abc123"),
+        lastId = Some("step_abc456"),
         hasMore = false
       )
 

--- a/openai/src/test/scala/sttp/ai/openai/openai/requests/vectorstore/VectorStoreDataSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/requests/vectorstore/VectorStoreDataSpec.scala
@@ -113,8 +113,8 @@ class VectorStoreDataSpec extends AnyFlatSpec with Matchers with EitherValues {
     val givenResponse = ListVectorStoresResponse(
       `object` = "list",
       data = Seq(first, second),
-      firstId = "vs_abc123",
-      lastId = "vs_abc456",
+      firstId = Some("vs_abc123"),
+      lastId = Some("vs_abc456"),
       hasMore = false
     )
 
@@ -126,6 +126,20 @@ class VectorStoreDataSpec extends AnyFlatSpec with Matchers with EitherValues {
 
     // then
     serializedJson.value shouldBe givenResponse
+  }
+
+  "Empty vector store list response with null cursors" should "be properly deserialized from Json" in {
+    // when
+    val deserialized: Either[Exception, ListVectorStoresResponse] = decode[ListVectorStoresResponse](VectorStoreFixture.jsonEmptyList)
+
+    // then
+    deserialized.value shouldBe ListVectorStoresResponse(
+      `object` = "list",
+      data = Seq.empty,
+      firstId = None,
+      lastId = None,
+      hasMore = false
+    )
   }
 
   "Delete of vector stores response" should "be properly deserialized from Json" in {

--- a/openai/src/test/scala/sttp/ai/openai/openai/requests/vectorstore/file/VectorStoreFileDataSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/requests/vectorstore/file/VectorStoreFileDataSpec.scala
@@ -47,6 +47,11 @@ class VectorStoreFileDataSpec extends AnyFlatSpec with Matchers with EitherValue
     serializedJson shouldBe jsonRequest
   }
 
+  "FileStatus.toApiValue" should "agree with the JSON codec for every status" in
+    Seq[FileStatus](InProgress, Completed, Failed, Cancelled).foreach { status =>
+      Some(FileStatus.toApiValue(status)) shouldBe status.asJson.asString
+    }
+
   "Vector store file search params" should "be properly converted to query parameters" in {
     // given
     val givenRequest = ListVectorStoreFilesBody(limit = 5, after = Some("111"), filter = Some(InProgress))

--- a/openai/src/test/scala/sttp/ai/openai/openai/requests/vectorstore/file/VectorStoreFileDataSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/requests/vectorstore/file/VectorStoreFileDataSpec.scala
@@ -47,6 +47,17 @@ class VectorStoreFileDataSpec extends AnyFlatSpec with Matchers with EitherValue
     serializedJson shouldBe jsonRequest
   }
 
+  "Vector store file search params" should "be properly converted to query parameters" in {
+    // given
+    val givenRequest = ListVectorStoreFilesBody(limit = 5, after = Some("111"), filter = Some(InProgress))
+
+    // when
+    val params = givenRequest.toMap
+
+    // then
+    params shouldBe Map("limit" -> "5", "order" -> "desc", "after" -> "111", "filter" -> "in_progress")
+  }
+
   "Vector store file response" should "be properly deserialized from Json" in {
     import sttp.ai.openai.requests.vectorstore.file.VectorStoreFileResponseData.VectorStoreFile._
     // given
@@ -114,8 +125,8 @@ class VectorStoreFileDataSpec extends AnyFlatSpec with Matchers with EitherValue
     val givenResponse = ListVectorStoreFilesResponse(
       `object` = "list",
       data = Seq(one, two),
-      firstId = "vsf_1",
-      lastId = "vsf_2",
+      firstId = Some("vsf_1"),
+      lastId = Some("vsf_2"),
       hasMore = true
     )
     val jsonResponse = VectorStoreFileFixture.jsonList
@@ -126,6 +137,21 @@ class VectorStoreFileDataSpec extends AnyFlatSpec with Matchers with EitherValue
 
     // then
     serializedJson.value shouldBe givenResponse
+  }
+
+  "Empty vector store file list response with null cursors" should "be properly deserialized from Json" in {
+    // when
+    val deserialized: Either[Exception, ListVectorStoreFilesResponse] =
+      decode[ListVectorStoreFilesResponse](VectorStoreFileFixture.jsonEmptyList)
+
+    // then
+    deserialized.value shouldBe ListVectorStoreFilesResponse(
+      `object` = "list",
+      data = Seq.empty,
+      firstId = None,
+      lastId = None,
+      hasMore = false
+    )
   }
 
   "Delete of vector store file response" should "be properly deserialized from Json" in {

--- a/openai/src/test/scala/sttp/ai/openai/openai/requests/vectorstore/file/batch/VectorStoreFileBatchDataSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/requests/vectorstore/file/batch/VectorStoreFileBatchDataSpec.scala
@@ -10,10 +10,7 @@ import sttp.ai.openai.json.OpenAIDerivedCodecs._
 import sttp.ai.openai.json.OpenAIManualCodecs._
 import sttp.ai.openai.requests.vectorstore.VectorStoreResponseData.FileCounts
 import sttp.ai.openai.requests.vectorstore.file.{Completed, InProgress}
-import sttp.ai.openai.requests.vectorstore.file.batch.VectorStoreFileBatchRequestBody.{
-  CreateVectorStoreFileBatchBody,
-  ListVectorStoreFilesInBatchBody
-}
+import sttp.ai.openai.requests.vectorstore.file.batch.VectorStoreFileBatchRequestBody.CreateVectorStoreFileBatchBody
 import sttp.ai.openai.requests.vectorstore.file.batch.VectorStoreFileBatchResponseData.VectorStoreFileBatch
 
 class VectorStoreFileBatchDataSpec extends AnyFlatSpec with Matchers with EitherValues {
@@ -28,35 +25,6 @@ class VectorStoreFileBatchDataSpec extends AnyFlatSpec with Matchers with Either
 
     // then
     serializedJson shouldBe jsonRequest
-  }
-
-  "Vector store files in batch search params" should "be properly serialized to Json" in {
-    // given
-    val givenRequest = ListVectorStoreFilesInBatchBody(
-      limit = 30,
-      order = "asc",
-      after = Some("111"),
-      before = Some("222"),
-      filter = Some(InProgress)
-    )
-    val jsonRequest: io.circe.Json = parse(VectorStoreFileBatchFixture.jsonListRequest).value
-
-    // when
-    val serializedJson: io.circe.Json = givenRequest.asJson.deepDropNullValues
-
-    // then
-    serializedJson shouldBe jsonRequest
-  }
-
-  "Vector store files in batch search params" should "be properly converted to query parameters" in {
-    // given
-    val givenRequest = ListVectorStoreFilesInBatchBody(limit = 5, after = Some("111"), filter = Some(Completed))
-
-    // when
-    val params = givenRequest.toMap
-
-    // then
-    params shouldBe Map("limit" -> "5", "order" -> "desc", "after" -> "111", "filter" -> "completed")
   }
 
   "In-progress vector store file batch response" should "be properly deserialized from Json" in {

--- a/openai/src/test/scala/sttp/ai/openai/openai/requests/vectorstore/file/batch/VectorStoreFileBatchDataSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/requests/vectorstore/file/batch/VectorStoreFileBatchDataSpec.scala
@@ -1,0 +1,100 @@
+package sttp.ai.openai.requests.vectorstore.file.batch
+
+import io.circe.parser.{decode, parse}
+import io.circe.syntax._
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.ai.openai.fixtures.VectorStoreFileBatchFixture
+import sttp.ai.openai.json.OpenAIDerivedCodecs._
+import sttp.ai.openai.json.OpenAIManualCodecs._
+import sttp.ai.openai.requests.vectorstore.VectorStoreResponseData.FileCounts
+import sttp.ai.openai.requests.vectorstore.file.{Completed, InProgress}
+import sttp.ai.openai.requests.vectorstore.file.batch.VectorStoreFileBatchRequestBody.{
+  CreateVectorStoreFileBatchBody,
+  ListVectorStoreFilesInBatchBody
+}
+import sttp.ai.openai.requests.vectorstore.file.batch.VectorStoreFileBatchResponseData.VectorStoreFileBatch
+
+class VectorStoreFileBatchDataSpec extends AnyFlatSpec with Matchers with EitherValues {
+
+  "Given create vector store file batch request" should "be properly serialized to Json" in {
+    // given
+    val givenRequest = CreateVectorStoreFileBatchBody(fileIds = Seq("file_1", "file_2"))
+    val jsonRequest: io.circe.Json = parse(VectorStoreFileBatchFixture.jsonCreateRequest).value
+
+    // when
+    val serializedJson: io.circe.Json = givenRequest.asJson.deepDropNullValues
+
+    // then
+    serializedJson shouldBe jsonRequest
+  }
+
+  "Vector store files in batch search params" should "be properly serialized to Json" in {
+    // given
+    val givenRequest = ListVectorStoreFilesInBatchBody(
+      limit = 30,
+      order = "asc",
+      after = Some("111"),
+      before = Some("222"),
+      filter = Some(InProgress)
+    )
+    val jsonRequest: io.circe.Json = parse(VectorStoreFileBatchFixture.jsonListRequest).value
+
+    // when
+    val serializedJson: io.circe.Json = givenRequest.asJson.deepDropNullValues
+
+    // then
+    serializedJson shouldBe jsonRequest
+  }
+
+  "Vector store files in batch search params" should "be properly converted to query parameters" in {
+    // given
+    val givenRequest = ListVectorStoreFilesInBatchBody(limit = 5, after = Some("111"), filter = Some(Completed))
+
+    // when
+    val params = givenRequest.toMap
+
+    // then
+    params shouldBe Map("limit" -> "5", "order" -> "desc", "after" -> "111", "filter" -> "completed")
+  }
+
+  "In-progress vector store file batch response" should "be properly deserialized from Json" in {
+    // given
+    val givenResponse = VectorStoreFileBatch(
+      id = "vsfb_1",
+      `object` = "vector_store.file_batch",
+      createdAt = 1698107661,
+      vectorStoreId = "vs_1",
+      status = InProgress,
+      fileCounts = FileCounts(inProgress = 2, completed = 0, failed = 0, cancelled = 0, total = 2)
+    )
+
+    // when
+    val deserialized: Either[Exception, VectorStoreFileBatch] =
+      decode[VectorStoreFileBatch](VectorStoreFileBatchFixture.jsonObjectInProgress)
+
+    // then
+    deserialized.value shouldBe givenResponse
+  }
+
+  "Completed vector store file batch response" should "be properly deserialized from Json" in {
+    // given
+    val givenResponse = VectorStoreFileBatch(
+      id = "vsfb_1",
+      `object` = "vector_store.file_batch",
+      createdAt = 1698107661,
+      vectorStoreId = "vs_1",
+      status = Completed,
+      fileCounts = FileCounts(inProgress = 0, completed = 1, failed = 1, cancelled = 0, total = 2)
+    )
+
+    // when
+    val deserialized: Either[Exception, VectorStoreFileBatch] =
+      decode[VectorStoreFileBatch](VectorStoreFileBatchFixture.jsonObjectCompleted)
+
+    // then
+    deserialized.value shouldBe givenResponse
+  }
+
+}


### PR DESCRIPTION
Adds the four OpenAI vector store file batch endpoints (create, retrieve, cancel, list files) to OpenAI and OpenAISyncClient, with request/response models under requests/vectorstore/file/batch and codecs for Scala 2 and 3.

Also fixes two pre-existing bugs found while validating against the live API:
- the `filter` query parameter on list requests was sent as "Completed" instead of the API's snake_case "completed" (FileStatus.toApiValue)
- ListVectorStoreFilesResponse / ListVectorStoresResponse could not decode an empty page, where the API returns first_id/last_id as null; both fields are now Option[String]